### PR TITLE
fix(hash): fix the bug of removing self-table-element in function(mln_hash_iterate) 

### DIFF
--- a/src/mln_hash.c
+++ b/src/mln_hash.c
@@ -375,7 +375,9 @@ int mln_hash_iterate(mln_hash_t *h, hash_iterate_handler handler, void *udata)
     end = h->tbl + h->len;
     mln_hash_entry_t *he;
     for (; mgr < end; ++mgr) {
-        for (he = mgr->head; he != NULL; he = he->next) {
+	mln_hash_entry_t* next_it;
+        for (he = mgr->head; he != NULL; he = next_it) {
+	    next_it = he->next;
             if (handler != NULL && handler(he->key, he->val, udata) < 0)
                 return -1;
         }


### PR DESCRIPTION
当我想要在遍历哈希表,执行 mln_hash_iterate 的时候利用void *udata传递遍历的mln_hash_t 类型的句柄，在遍历函数中使用mln_hash_remove 发现在同一个哈希桶内只能有第一个元素被正确执行,即使我的函数返回了继续执行的0， 查阅文档发现并没有相关的解释，也没有说明在mln_hash_iterate 中不能对自身的结构做变化, 查阅源码后发现是由于在遍历同一个桶的时候,先执行了用户的函数 再进行下一次迭代, 所以我将迭代记录改在前面,用户函数改在后面。 PS:( 除了删除 在遍历函数里面做所有对自身表结构有变化的操作都可能导致一系列未定义的错误 ，比如插入等 希望官方能够出一份相关的禁止文档 或者引入迭代器，方便用户更方便的对表内元素进行操作）