### PR TITLE
feat(hash):add iterator module

### DIFF
--- a/include/mln_hash.h
+++ b/include/mln_hash.h
@@ -9,8 +9,9 @@
 #include "mln_types.h"
 
 typedef struct mln_hash_s mln_hash_t;
+typedef struct mln_hash_entry_s mln_hash_iterator_t;
 
-typedef int (*hash_iterate_handler)(void * /*key*/, void * /*val*/, void *);
+typedef int (*hash_iterate_handler)(mln_hash_iterator_t*, void *);
 typedef mln_u64_t (*hash_calc_handler)(mln_hash_t *, void *);
 /*
  * cmp_handler's return value: 0 -- not matched, !0 -- matched.
@@ -26,6 +27,13 @@ typedef enum mln_hash_flag {
     M_HASH_F_KEY,
     M_HASH_F_KV
 } mln_hash_flag_t;
+
+typedef enum mln_hash_type_e {
+    M_HASH_ITERATOR,
+    M_HASH_FREE,
+    M_HASH_ZOMBIE,
+    
+} mln_hash_type_t;
 
 struct mln_hash_attr {
     hash_calc_handler        hash;
@@ -45,6 +53,8 @@ typedef struct mln_hash_entry_s {
     struct mln_hash_entry_s *next;
     void                    *val;
     void                    *key;
+    mln_hash_type_t          it_type;
+    mln_hash_t              *it_belong;
 } mln_hash_entry_t;
 
 typedef struct {
@@ -68,6 +78,7 @@ struct mln_hash_s {
     hash_pool_free_handler   pool_free;
 };
 
+
 extern int
 mln_hash_init(mln_hash_t *h, struct mln_hash_attr *attr) __NONNULL2(1,2);
 extern void mln_hash_destroy(mln_hash_t *h, mln_hash_flag_t flg);
@@ -75,9 +86,9 @@ extern mln_hash_t *
 mln_hash_new(struct mln_hash_attr *attr) __NONNULL1(1);
 extern void
 mln_hash_free(mln_hash_t *h, mln_hash_flag_t flg);
-extern void *
+extern mln_hash_iterator_t *
 mln_hash_search(mln_hash_t *h, void *key) __NONNULL2(1,2);
-extern void *
+extern mln_hash_iterator_t *
 mln_hash_search_iterator(mln_hash_t *h, void *key, int **ctx) __NONNULL3(1,2,3);
 /*
  * mln_hash_replace():
@@ -88,15 +99,27 @@ mln_hash_search_iterator(mln_hash_t *h, void *key, int **ctx) __NONNULL3(1,2,3);
 extern int
 mln_hash_replace(mln_hash_t *h, void *key, void *val) __NONNULL3(1,2,3);
 extern int
-mln_hash_insert(mln_hash_t *h, void *key, void *val) __NONNULL2(1,2);
+mln_hash_insert(mln_hash_t *h,mln_hash_iterator_t *it) __NONNULL2(1,2);
 extern void
-mln_hash_remove(mln_hash_t *h, void *key, mln_hash_flag_t flg) __NONNULL2(1,2);
+mln_hash_remove(mln_hash_t *h,mln_hash_iterator_t *it) __NONNULL2(1,2);
 extern int
 mln_hash_iterate(mln_hash_t *h, hash_iterate_handler handler, void *udata) __NONNULL1(1);
 extern void *
 mln_hash_change_value(mln_hash_t *h, void *key, void *new_value) __NONNULL2(1,2);
 extern int mln_hash_key_exist(mln_hash_t *h, void *key) __NONNULL2(1,2);
 extern void mln_hash_reset(mln_hash_t *h, mln_hash_flag_t flg) __NONNULL1(1);
+
+extern void * 
+mln_hash_iterator_key_get(mln_hash_iterator_t *it) __NONNULL1(1);
+extern void * 
+mln_hash_iterator_value_get(mln_hash_iterator_t *it) __NONNULL1(1);
+extern mln_hash_iterator_t *
+mln_hash_iterator_new(mln_hash_t* h,void *key,void *val) __NONNULL2(1,2);
+extern void
+mln_hash_iterator_free(mln_hash_iterator_t *it,mln_hash_flag_t flg) __NONNULL1(1);
+extern void* 
+mln_hash_iterator_value_set(mln_hash_iterator_t* it,void *val) __NONNULL1(1);
+
 
 #endif
 


### PR DESCRIPTION
给hash模块添加了迭代器模块 没有改动原代码
使用示例:
mln_hash_t * h;
mln_hash_iterator it;
mln_hash_it_begin(h,&it);
for(;!mln_hash_it_is_end(h,&it);mln_hash_it_next(h,&it))
{
    int key = *(int*)mln_hash_it_get_key(&it);
    mln_hash_test_t* value = (mln_hash_test_t*)mln_hash_it_get_value(&it);
    printf("key:%d value:%d\n",key,value->val);
}


或者
mln_hash_iterator it;
mln_hash_it_begin(h,&it);
for(;!mln_hash_it_is_end(h,&it);)
{
    mln_hash_iterator new_it;
    mln_hash_it_get_next(h,&it,&new_it);
    mln_hash_it_remove(h,&it,M_HASH_F_VAL);
    mln_hash_it_cpy(&it,&new_it);
}