### PR TITLE
perf(aes): optimize AES with T-table lookup, add comprehensive tests

### DIFF
--- a/include/mln_aes.h
+++ b/include/mln_aes.h
@@ -33,6 +33,7 @@
 typedef struct {
     mln_u32_t bits;
     mln_u32_t w[60];
+    mln_u32_t dw[60];
 } mln_aes_t;
 
 

--- a/src/mln_aes.c
+++ b/src/mln_aes.c
@@ -8,14 +8,6 @@
 #include "mln_aes.h"
 #include "mln_func.h"
 
-static inline void mln_aes_addroundkey(mln_u32_t *state, mln_u32_t *roundkey, int round);
-static inline void mln_aes_mixcolume(mln_u32_t *state);
-static inline void mln_aes_bytesub(mln_u32_t *state);
-static inline void mln_aes_shiftrow(mln_u32_t *state);
-static inline void mln_aes_invshiftrow(mln_u32_t *state);
-static inline void mln_aes_invbytesub(mln_u32_t *state);
-static inline void mln_aes_invmixcolume(mln_u32_t *state);
-
 static mln_u8_t sbox[] = {
     0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
     0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
@@ -54,19 +46,82 @@ static mln_u8_t rsbox[] = {
     0x17, 0x2b, 0x04, 0x7e, 0xba, 0x77, 0xd6, 0x26, 0xe1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0c, 0x7d
 };
 
-static mln_u32_t rcon[] = {  
-    0x0,  
-    0x01000000,  
-    0x02000000,  
-    0x04000000,  
-    0x08000000,  
-    0x10000000,  
-    0x20000000,  
-    0x40000000,  
-    0x80000000,  
-    0x1b000000,  
-    0x36000000  
+static mln_u32_t rcon[] = {
+    0x0,
+    0x01000000,
+    0x02000000,
+    0x04000000,
+    0x08000000,
+    0x10000000,
+    0x20000000,
+    0x40000000,
+    0x80000000,
+    0x1b000000,
+    0x36000000
 };
+
+/*
+ * T-tables: precomputed SubBytes + MixColumns combined lookup.
+ * Te0[x] = { S[x]·2, S[x]·1, S[x]·1, S[x]·3 } as big-endian u32
+ * Te1 = RotWord(Te0, 8), Te2 = RotWord(Te0, 16), Te3 = RotWord(Te0, 24)
+ * Td0-Td3: same idea with inverse S-box and inverse MixColumns.
+ */
+static mln_u32_t Te0[256];
+static mln_u32_t Te1[256];
+static mln_u32_t Te2[256];
+static mln_u32_t Te3[256];
+static mln_u32_t Td0[256];
+static mln_u32_t Td1[256];
+static mln_u32_t Td2[256];
+static mln_u32_t Td3[256];
+static int ttables_inited = 0;
+
+MLN_FUNC(static inline, mln_u8_t, xtime, (mln_u8_t x), (x), \
+{
+    return (x << 1) ^ (((x >> 7) & 1) * 0x1b);
+})
+
+MLN_FUNC(static inline, mln_u8_t, gmul, (mln_u8_t a, mln_u8_t b), (a, b), \
+{
+    mln_u8_t p = 0;
+    int i;
+    for (i = 0; i < 8; ++i) {
+        if (b & 1) p ^= a;
+        a = xtime(a);
+        b >>= 1;
+    }
+    return p;
+})
+
+MLN_FUNC_VOID(static, void, mln_aes_init_ttables, (void), (), \
+{
+    int i;
+    for (i = 0; i < 256; ++i) {
+        mln_u8_t s = sbox[i];
+        mln_u8_t s2 = xtime(s);
+        mln_u8_t s3 = s2 ^ s;
+        /* Te0[i] = { s·2, s·1, s·1, s·3 } big-endian */
+        mln_u32_t t = ((mln_u32_t)s2 << 24) | ((mln_u32_t)s << 16) | ((mln_u32_t)s << 8) | (mln_u32_t)s3;
+        Te0[i] = t;
+        Te1[i] = (t << 24) | (t >> 8);
+        Te2[i] = (t << 16) | (t >> 16);
+        Te3[i] = (t << 8)  | (t >> 24);
+    }
+    for (i = 0; i < 256; ++i) {
+        mln_u8_t s = rsbox[i];
+        mln_u8_t se = gmul(s, 0x0e);
+        mln_u8_t s9 = gmul(s, 0x09);
+        mln_u8_t sd = gmul(s, 0x0d);
+        mln_u8_t sb = gmul(s, 0x0b);
+        /* Td0[i] = { RS[i]·0e, RS[i]·09, RS[i]·0d, RS[i]·0b } */
+        mln_u32_t t = ((mln_u32_t)se << 24) | ((mln_u32_t)s9 << 16) | ((mln_u32_t)sd << 8) | (mln_u32_t)sb;
+        Td0[i] = t;
+        Td1[i] = (t << 24) | (t >> 8);
+        Td2[i] = (t << 16) | (t >> 16);
+        Td3[i] = (t << 8)  | (t >> 24);
+    }
+    ttables_inited = 1;
+})
 
 #define mln_aes_rotbyte(val) (((val >> 24) & 0xff) | ((val & 0xffffff) << 8))
 
@@ -79,6 +134,8 @@ MLN_FUNC(, int, mln_aes_init, (mln_aes_t *a, mln_u8ptr_t key, mln_u32_t bits), (
     int i;
     mln_u32_t nk, times;
     mln_u32_t temp, *roundkey = a->w;
+
+    if (!ttables_inited) mln_aes_init_ttables();
 
     switch (bits) {
         case M_AES_128:
@@ -114,7 +171,40 @@ MLN_FUNC(, int, mln_aes_init, (mln_aes_t *a, mln_u8ptr_t key, mln_u32_t bits), (
     for (; i < 60; ++i) roundkey[i] = 0;
 
     a->bits = bits;
-    
+
+    /* Precompute decryption round keys: apply InvMixColumns to middle round keys */
+    {
+        mln_u32_t nr_val;
+        int r;
+        switch (bits) {
+            case M_AES_128: nr_val = __MLN_AES128_Nr; break;
+            case M_AES_192: nr_val = __MLN_AES192_Nr; break;
+            default:        nr_val = __MLN_AES256_Nr; break;
+        }
+        /* First and last round keys are used as-is */
+        for (i = 0; i < 4; ++i) {
+            a->dw[i] = roundkey[i];
+            a->dw[nr_val * 4 + i] = roundkey[nr_val * 4 + i];
+        }
+        /* Middle round keys get InvMixColumns applied */
+        for (r = 1; r < (int)nr_val; ++r) {
+            for (i = 0; i < 4; ++i) {
+                mln_u32_t w = roundkey[r * 4 + i];
+                mln_u8_t b0 = (w >> 24) & 0xff;
+                mln_u8_t b1 = (w >> 16) & 0xff;
+                mln_u8_t b2 = (w >> 8) & 0xff;
+                mln_u8_t b3 = w & 0xff;
+                a->dw[r * 4 + i] =
+                    ((mln_u32_t)(gmul(b0, 0x0e) ^ gmul(b1, 0x0b) ^ gmul(b2, 0x0d) ^ gmul(b3, 0x09)) << 24) |
+                    ((mln_u32_t)(gmul(b0, 0x09) ^ gmul(b1, 0x0e) ^ gmul(b2, 0x0b) ^ gmul(b3, 0x0d)) << 16) |
+                    ((mln_u32_t)(gmul(b0, 0x0d) ^ gmul(b1, 0x09) ^ gmul(b2, 0x0e) ^ gmul(b3, 0x0b)) << 8)  |
+                    ((mln_u32_t)(gmul(b0, 0x0b) ^ gmul(b1, 0x0d) ^ gmul(b2, 0x09) ^ gmul(b3, 0x0e)));
+            }
+        }
+        /* Zero out remaining dw entries */
+        for (i = (nr_val + 1) * 4; i < 60; ++i) a->dw[i] = 0;
+    }
+
     return 0;
 })
 
@@ -142,194 +232,116 @@ MLN_FUNC_VOID(, void, mln_aes_pool_free, (mln_aes_t *a), (a), {
     mln_alloc_free(a);
 })
 
-MLN_FUNC_VOID(static inline, void, mln_aes_addroundkey, (mln_u32_t *state, mln_u32_t *roundkey, int round), (state, roundkey, round), {
-    int i, j;
-    mln_u8_t b;
-    for (i = 0; i < sizeof(mln_u32_t); ++i) {
-        for (j = 0; j < sizeof(mln_u32_t); ++j) {
-            b = (state[j] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-            state[j] ^= ((mln_u32_t)b) << ((sizeof(mln_u32_t)-1-i) << 3);
-            b ^= ((roundkey[round*__MLN_AES_Nb+i] >> ((sizeof(mln_u32_t)-1-j) << 3)) & 0xff);
-            state[j] |= ((((mln_u32_t)b) & 0xff) << ((sizeof(mln_u32_t)-1-i) << 3));
-        }
-    }
-})
-
-MLN_FUNC_VOID(static inline, void, mln_aes_mixcolume, (mln_u32_t *state), (state), {
-    int i;
-    mln_u8_t _0, _1, _2, _3, b;
-
-    for (i = 0; i < 4; ++i) {
-        _0 = (state[0] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-        _1 = (state[1] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-        _2 = (state[2] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-        _3 = (state[3] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-
-        state[0] ^= (((mln_u32_t)_0) << ((sizeof(mln_u32_t)-1-i) << 3));
-        b = __MLN_AES_MULTIB_02(_0) ^ __MLN_AES_MULTIB_03(_1) ^ __MLN_AES_MULTIB_01(_2) ^ __MLN_AES_MULTIB_01(_3);
-        state[0] |= (((mln_u32_t)b) << ((sizeof(mln_u32_t)-1-i) << 3));
-
-        state[1] ^= (((mln_u32_t)_1) << ((sizeof(mln_u32_t)-1-i) << 3));
-        b = __MLN_AES_MULTIB_01(_0) ^ __MLN_AES_MULTIB_02(_1) ^ __MLN_AES_MULTIB_03(_2) ^ __MLN_AES_MULTIB_01(_3);
-        state[1] |= (((mln_u32_t)b) << ((sizeof(mln_u32_t)-1-i) << 3));
-
-        state[2] ^= (((mln_u32_t)_2) << ((sizeof(mln_u32_t)-1-i) << 3));
-        b = __MLN_AES_MULTIB_01(_0) ^ __MLN_AES_MULTIB_01(_1) ^ __MLN_AES_MULTIB_02(_2) ^ __MLN_AES_MULTIB_03(_3);
-        state[2] |= (((mln_u32_t)b) << ((sizeof(mln_u32_t)-1-i) << 3));
-
-        state[3] ^= (((mln_u32_t)_3) << ((sizeof(mln_u32_t)-1-i) << 3));
-        b = __MLN_AES_MULTIB_03(_0) ^ __MLN_AES_MULTIB_01(_1) ^ __MLN_AES_MULTIB_01(_2) ^ __MLN_AES_MULTIB_02(_3);
-        state[3] |= (((mln_u32_t)b) << ((sizeof(mln_u32_t)-1-i) << 3));
-    }
-})
-
-MLN_FUNC_VOID(static inline, void, mln_aes_bytesub, (mln_u32_t *state), (state), {
-    mln_u32_t i, j;
-    mln_u8_t b;
-
-    for (i = 0; i < sizeof(mln_u32_t); ++i) {
-        for (j = 0; j < sizeof(mln_u32_t); ++j) {
-            b = (state[j] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-            state[j] ^= ((mln_u32_t)b) << ((sizeof(mln_u32_t)-1-i) << 3);
-            state[j] |= ((((mln_u32_t)sbox[b]) & 0xff) << ((sizeof(mln_u32_t)-1-i) << 3));
-        }
-    }
-})
-
-MLN_FUNC_VOID(static inline, void, mln_aes_shiftrow, (mln_u32_t *state), (state), {
-    state[1] = (((state[1] << 8) | (state[1] >> 24)) & 0xffffffff);
-    state[2] = (((state[2] << 16) | (state[2] >> 16)) & 0xffffffff);
-    state[3] = (((state[3] << 24) | (state[3] >> 8)) & 0xffffffff);
-})
-
+/*
+ * T-table based AES encrypt.
+ * State is column-major: state[c] = col c of AES state, big-endian.
+ * This matches the round key layout w[c] directly, so AddRoundKey is a simple XOR.
+ * Each inner round combines SubBytes + ShiftRows + MixColumns via T-table lookups.
+ */
 MLN_FUNC(, int, mln_aes_encrypt, (mln_aes_t *a, mln_u8ptr_t text), (a, text), {
-    mln_u32_t state[4] = {0, 0, 0, 0}, i, j, round, nr;
+    mln_u32_t s0, s1, s2, s3;
+    mln_u32_t t0, t1, t2, t3;
+    mln_u32_t nr, round;
+    mln_u32_t *rk = a->w;
 
     switch (a->bits) {
-        case M_AES_128:
-            nr = __MLN_AES128_Nr;
-            break;
-        case M_AES_192:
-            nr = __MLN_AES192_Nr;
-            break;
-        case M_AES_256:
-            nr = __MLN_AES256_Nr;
-            break;
+        case M_AES_128: nr = __MLN_AES128_Nr; break;
+        case M_AES_192: nr = __MLN_AES192_Nr; break;
+        case M_AES_256: nr = __MLN_AES256_Nr; break;
         default: return -1;
     }
 
-    for (i = 0; i < sizeof(mln_u32_t); ++i) {
-        for (j = 0; j < sizeof(mln_u32_t); ++j) {
-            state[j] |= (((mln_u32_t)(text[(i<<2) + j] & 0xff)) << ((sizeof(mln_u32_t)-1-i) << 3));
-        }
-    }
+    /* Load state as columns (big-endian), XOR with round key 0 */
+    s0 = (((mln_u32_t)text[ 0] << 24) | ((mln_u32_t)text[ 1] << 16) | ((mln_u32_t)text[ 2] << 8) | (mln_u32_t)text[ 3]) ^ rk[0];
+    s1 = (((mln_u32_t)text[ 4] << 24) | ((mln_u32_t)text[ 5] << 16) | ((mln_u32_t)text[ 6] << 8) | (mln_u32_t)text[ 7]) ^ rk[1];
+    s2 = (((mln_u32_t)text[ 8] << 24) | ((mln_u32_t)text[ 9] << 16) | ((mln_u32_t)text[10] << 8) | (mln_u32_t)text[11]) ^ rk[2];
+    s3 = (((mln_u32_t)text[12] << 24) | ((mln_u32_t)text[13] << 16) | ((mln_u32_t)text[14] << 8) | (mln_u32_t)text[15]) ^ rk[3];
 
-    mln_aes_addroundkey(state, a->w, 0);
-
+    /* Inner rounds: SubBytes + ShiftRows + MixColumns via T-tables */
     for (round = 1; round < nr; ++round) {
-        mln_aes_bytesub(state);
-        mln_aes_shiftrow(state);
-        mln_aes_mixcolume(state);
-        mln_aes_addroundkey(state, a->w, round);
+        rk += 4;
+        t0 = Te0[(s0 >> 24) & 0xff] ^ Te1[(s1 >> 16) & 0xff] ^ Te2[(s2 >> 8) & 0xff] ^ Te3[s3 & 0xff] ^ rk[0];
+        t1 = Te0[(s1 >> 24) & 0xff] ^ Te1[(s2 >> 16) & 0xff] ^ Te2[(s3 >> 8) & 0xff] ^ Te3[s0 & 0xff] ^ rk[1];
+        t2 = Te0[(s2 >> 24) & 0xff] ^ Te1[(s3 >> 16) & 0xff] ^ Te2[(s0 >> 8) & 0xff] ^ Te3[s1 & 0xff] ^ rk[2];
+        t3 = Te0[(s3 >> 24) & 0xff] ^ Te1[(s0 >> 16) & 0xff] ^ Te2[(s1 >> 8) & 0xff] ^ Te3[s2 & 0xff] ^ rk[3];
+        s0 = t0; s1 = t1; s2 = t2; s3 = t3;
     }
 
-    mln_aes_bytesub(state);
-    mln_aes_shiftrow(state);
-    mln_aes_addroundkey(state, a->w, nr);
+    /* Last round: SubBytes + ShiftRows (no MixColumns) */
+    rk += 4;
+    t0 = ((mln_u32_t)sbox[(s0 >> 24) & 0xff] << 24) | ((mln_u32_t)sbox[(s1 >> 16) & 0xff] << 16) |
+         ((mln_u32_t)sbox[(s2 >> 8) & 0xff] << 8)   |  (mln_u32_t)sbox[s3 & 0xff];
+    t1 = ((mln_u32_t)sbox[(s1 >> 24) & 0xff] << 24) | ((mln_u32_t)sbox[(s2 >> 16) & 0xff] << 16) |
+         ((mln_u32_t)sbox[(s3 >> 8) & 0xff] << 8)   |  (mln_u32_t)sbox[s0 & 0xff];
+    t2 = ((mln_u32_t)sbox[(s2 >> 24) & 0xff] << 24) | ((mln_u32_t)sbox[(s3 >> 16) & 0xff] << 16) |
+         ((mln_u32_t)sbox[(s0 >> 8) & 0xff] << 8)   |  (mln_u32_t)sbox[s1 & 0xff];
+    t3 = ((mln_u32_t)sbox[(s3 >> 24) & 0xff] << 24) | ((mln_u32_t)sbox[(s0 >> 16) & 0xff] << 16) |
+         ((mln_u32_t)sbox[(s1 >> 8) & 0xff] << 8)   |  (mln_u32_t)sbox[s2 & 0xff];
+    s0 = t0 ^ rk[0]; s1 = t1 ^ rk[1]; s2 = t2 ^ rk[2]; s3 = t3 ^ rk[3];
 
-    for (i = 0; i < sizeof(mln_u32_t); ++i) {
-        for (j = 0; j < sizeof(mln_u32_t); ++j) {
-            text[(i << 2)+j] = (state[j] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-        }
-    }
+    /* Store state back as bytes (big-endian columns) */
+    text[ 0] = (s0 >> 24) & 0xff; text[ 1] = (s0 >> 16) & 0xff; text[ 2] = (s0 >> 8) & 0xff; text[ 3] = s0 & 0xff;
+    text[ 4] = (s1 >> 24) & 0xff; text[ 5] = (s1 >> 16) & 0xff; text[ 6] = (s1 >> 8) & 0xff; text[ 7] = s1 & 0xff;
+    text[ 8] = (s2 >> 24) & 0xff; text[ 9] = (s2 >> 16) & 0xff; text[10] = (s2 >> 8) & 0xff; text[11] = s2 & 0xff;
+    text[12] = (s3 >> 24) & 0xff; text[13] = (s3 >> 16) & 0xff; text[14] = (s3 >> 8) & 0xff; text[15] = s3 & 0xff;
 
     return 0;
 })
 
+/*
+ * T-table based AES decrypt.
+ * InvShiftRows: row 1 shifts right 1, row 2 shifts right 2, row 3 shifts right 3.
+ * For column c: byte from row 0 comes from col c, row 1 from col (c+3)%4,
+ *               row 2 from col (c+2)%4, row 3 from col (c+1)%4.
+ */
 MLN_FUNC(, int, mln_aes_decrypt, (mln_aes_t *a, mln_u8ptr_t cipher), (a, cipher), {
-    mln_u32_t state[4] = {0, 0, 0, 0}, i, j, round, nr;
+    mln_u32_t s0, s1, s2, s3;
+    mln_u32_t t0, t1, t2, t3;
+    mln_u32_t nr, round;
+    mln_u32_t *rk;
 
     switch (a->bits) {
-        case M_AES_128:
-            nr = __MLN_AES128_Nr;
-            break;
-        case M_AES_192:
-            nr = __MLN_AES192_Nr;
-            break;
-        case M_AES_256:
-            nr = __MLN_AES256_Nr;
-            break;
+        case M_AES_128: nr = __MLN_AES128_Nr; break;
+        case M_AES_192: nr = __MLN_AES192_Nr; break;
+        case M_AES_256: nr = __MLN_AES256_Nr; break;
         default: return -1;
     }
 
-    for (i = 0; i < sizeof(mln_u32_t); ++i) {
-        for (j = 0; j < sizeof(mln_u32_t); ++j) {
-            state[j] |= (((mln_u32_t)(cipher[(i<<2) + j] & 0xff)) << ((sizeof(mln_u32_t)-1-i) << 3));
-        }
+    rk = a->dw + nr * 4;
+
+    /* Load state as columns (big-endian), XOR with last round key */
+    s0 = (((mln_u32_t)cipher[ 0] << 24) | ((mln_u32_t)cipher[ 1] << 16) | ((mln_u32_t)cipher[ 2] << 8) | (mln_u32_t)cipher[ 3]) ^ rk[0];
+    s1 = (((mln_u32_t)cipher[ 4] << 24) | ((mln_u32_t)cipher[ 5] << 16) | ((mln_u32_t)cipher[ 6] << 8) | (mln_u32_t)cipher[ 7]) ^ rk[1];
+    s2 = (((mln_u32_t)cipher[ 8] << 24) | ((mln_u32_t)cipher[ 9] << 16) | ((mln_u32_t)cipher[10] << 8) | (mln_u32_t)cipher[11]) ^ rk[2];
+    s3 = (((mln_u32_t)cipher[12] << 24) | ((mln_u32_t)cipher[13] << 16) | ((mln_u32_t)cipher[14] << 8) | (mln_u32_t)cipher[15]) ^ rk[3];
+
+    /* Inner rounds: InvSubBytes + InvShiftRows + InvMixColumns via Td-tables */
+    for (round = nr - 1; round > 0; --round) {
+        rk -= 4;
+        t0 = Td0[(s0 >> 24) & 0xff] ^ Td1[(s3 >> 16) & 0xff] ^ Td2[(s2 >> 8) & 0xff] ^ Td3[s1 & 0xff] ^ rk[0];
+        t1 = Td0[(s1 >> 24) & 0xff] ^ Td1[(s0 >> 16) & 0xff] ^ Td2[(s3 >> 8) & 0xff] ^ Td3[s2 & 0xff] ^ rk[1];
+        t2 = Td0[(s2 >> 24) & 0xff] ^ Td1[(s1 >> 16) & 0xff] ^ Td2[(s0 >> 8) & 0xff] ^ Td3[s3 & 0xff] ^ rk[2];
+        t3 = Td0[(s3 >> 24) & 0xff] ^ Td1[(s2 >> 16) & 0xff] ^ Td2[(s1 >> 8) & 0xff] ^ Td3[s0 & 0xff] ^ rk[3];
+        s0 = t0; s1 = t1; s2 = t2; s3 = t3;
     }
 
-    mln_aes_addroundkey(state, a->w, nr);
+    /* Last round: InvSubBytes + InvShiftRows (no InvMixColumns) */
+    rk -= 4;
+    t0 = ((mln_u32_t)rsbox[(s0 >> 24) & 0xff] << 24) | ((mln_u32_t)rsbox[(s3 >> 16) & 0xff] << 16) |
+         ((mln_u32_t)rsbox[(s2 >> 8) & 0xff] << 8)   |  (mln_u32_t)rsbox[s1 & 0xff];
+    t1 = ((mln_u32_t)rsbox[(s1 >> 24) & 0xff] << 24) | ((mln_u32_t)rsbox[(s0 >> 16) & 0xff] << 16) |
+         ((mln_u32_t)rsbox[(s3 >> 8) & 0xff] << 8)   |  (mln_u32_t)rsbox[s2 & 0xff];
+    t2 = ((mln_u32_t)rsbox[(s2 >> 24) & 0xff] << 24) | ((mln_u32_t)rsbox[(s1 >> 16) & 0xff] << 16) |
+         ((mln_u32_t)rsbox[(s0 >> 8) & 0xff] << 8)   |  (mln_u32_t)rsbox[s3 & 0xff];
+    t3 = ((mln_u32_t)rsbox[(s3 >> 24) & 0xff] << 24) | ((mln_u32_t)rsbox[(s2 >> 16) & 0xff] << 16) |
+         ((mln_u32_t)rsbox[(s1 >> 8) & 0xff] << 8)   |  (mln_u32_t)rsbox[s0 & 0xff];
+    s0 = t0 ^ rk[0]; s1 = t1 ^ rk[1]; s2 = t2 ^ rk[2]; s3 = t3 ^ rk[3];
 
-    for (round = nr-1; round > 0; --round) {
-        mln_aes_invshiftrow(state);
-        mln_aes_invbytesub(state);
-        mln_aes_addroundkey(state, a->w, round);
-        mln_aes_invmixcolume(state);
-    }
-
-    mln_aes_invshiftrow(state);
-    mln_aes_invbytesub(state);
-    mln_aes_addroundkey(state, a->w, 0);
-
-    for (i = 0; i < sizeof(mln_u32_t); ++i) {
-        for (j = 0; j < sizeof(mln_u32_t); ++j) {
-            cipher[(i << 2)+j] = (state[j] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-        }
-    }
+    /* Store state back as bytes */
+    cipher[ 0] = (s0 >> 24) & 0xff; cipher[ 1] = (s0 >> 16) & 0xff; cipher[ 2] = (s0 >> 8) & 0xff; cipher[ 3] = s0 & 0xff;
+    cipher[ 4] = (s1 >> 24) & 0xff; cipher[ 5] = (s1 >> 16) & 0xff; cipher[ 6] = (s1 >> 8) & 0xff; cipher[ 7] = s1 & 0xff;
+    cipher[ 8] = (s2 >> 24) & 0xff; cipher[ 9] = (s2 >> 16) & 0xff; cipher[10] = (s2 >> 8) & 0xff; cipher[11] = s2 & 0xff;
+    cipher[12] = (s3 >> 24) & 0xff; cipher[13] = (s3 >> 16) & 0xff; cipher[14] = (s3 >> 8) & 0xff; cipher[15] = s3 & 0xff;
 
     return 0;
 })
-
-MLN_FUNC_VOID(static inline, void, mln_aes_invshiftrow, (mln_u32_t *state), (state), {
-    state[1] = (((state[1] >> 8) | (state[1] << 24)) & 0xffffffff);
-    state[2] = (((state[2] >> 16) | (state[2] << 16)) & 0xffffffff);
-    state[3] = (((state[3] >> 24) | (state[3] << 8)) & 0xffffffff);
-})
-
-MLN_FUNC_VOID(static inline, void, mln_aes_invbytesub, (mln_u32_t *state), (state), {
-    mln_u32_t i, j;
-    mln_u8_t b;
-
-    for (i = 0; i < sizeof(mln_u32_t); ++i) {
-        for (j = 0; j < sizeof(mln_u32_t); ++j) {
-            b = (state[j] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-            state[j] ^= ((mln_u32_t)b) << ((sizeof(mln_u32_t)-1-i) << 3);
-            state[j] |= ((((mln_u32_t)rsbox[b]) & 0xff) << ((sizeof(mln_u32_t)-1-i) << 3));
-        }
-    }
-})
-
-MLN_FUNC_VOID(static inline, void, mln_aes_invmixcolume, (mln_u32_t *state), (state), {
-    int i;
-    mln_u8_t _0, _1, _2, _3;
-
-    for (i = 0; i < 4; ++i) {
-        _0 = (state[0] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-        _1 = (state[1] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-        _2 = (state[2] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-        _3 = (state[3] >> ((sizeof(mln_u32_t)-1-i) << 3)) & 0xff;
-
-        state[0] ^= (((mln_u32_t)_0) << ((sizeof(mln_u32_t)-1-i) << 3));
-        state[0] |= (((mln_u32_t)(__MLN_AES_MULTIB_0e(_0) ^ __MLN_AES_MULTIB_0b(_1) ^ __MLN_AES_MULTIB_0d(_2) ^ __MLN_AES_MULTIB_09(_3))) << ((sizeof(mln_u32_t)-1-i) << 3));
-
-        state[1] ^= (((mln_u32_t)_1) << ((sizeof(mln_u32_t)-1-i) << 3));
-        state[1] |= (((mln_u32_t)(__MLN_AES_MULTIB_09(_0) ^ __MLN_AES_MULTIB_0e(_1) ^ __MLN_AES_MULTIB_0b(_2) ^ __MLN_AES_MULTIB_0d(_3))) << ((sizeof(mln_u32_t)-1-i) << 3));
-
-        state[2] ^= (((mln_u32_t)_2) << ((sizeof(mln_u32_t)-1-i) << 3));
-        state[2] |= (((mln_u32_t)(__MLN_AES_MULTIB_0d(_0) ^ __MLN_AES_MULTIB_09(_1) ^ __MLN_AES_MULTIB_0e(_2) ^ __MLN_AES_MULTIB_0b(_3))) << ((sizeof(mln_u32_t)-1-i) << 3));
-
-        state[3] ^= (((mln_u32_t)_3) << ((sizeof(mln_u32_t)-1-i) << 3));
-        state[3] |= (((mln_u32_t)(__MLN_AES_MULTIB_0b(_0) ^ __MLN_AES_MULTIB_0d(_1) ^ __MLN_AES_MULTIB_09(_2) ^ __MLN_AES_MULTIB_0e(_3))) << ((sizeof(mln_u32_t)-1-i) << 3));
-    }
-})
-

--- a/t/aes.c
+++ b/t/aes.c
@@ -1,33 +1,314 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "mln_string.h"
 #include "mln_aes.h"
 
-int main(int argc, char *argv[])
+static int test_count = 0;
+static int pass_count = 0;
+static int fail_count = 0;
+
+static void check(const char *name, int cond)
+{
+    test_count++;
+    if (cond) {
+        pass_count++;
+    } else {
+        fail_count++;
+        fprintf(stderr, "FAIL: %s\n", name);
+    }
+}
+
+static void hex2bin(const char *hex, mln_u8_t *bin, int len)
+{
+    int i;
+    for (i = 0; i < len; i++) {
+        unsigned int v;
+        sscanf(hex + i * 2, "%2x", &v);
+        bin[i] = (mln_u8_t)v;
+    }
+}
+
+/* Test AES-128 basic encrypt/decrypt roundtrip */
+static void test_aes128_roundtrip(void)
 {
     mln_aes_t a;
     char p[] = "1234567890123456";
+    char saved[17];
     mln_string_t s;
 
-    if (mln_aes_init(&a, (mln_u8ptr_t)"abcdefghijklmnop", M_AES_128) < 0) {
-        fprintf(stderr, "aes init failed\n");
-        return -1;
-    }
+    memcpy(saved, p, 16);
+    saved[16] = '\0';
+
+    check("aes128_init", mln_aes_init(&a, (mln_u8ptr_t)"abcdefghijklmnop", M_AES_128) == 0);
 
     mln_string_set(&s, p);
-    if (mln_aes_encrypt(&a, s.data) < 0) {
-        fprintf(stderr, "aes encrypt failed\n");
-        return -1;
-    }
-    write(STDOUT_FILENO, s.data, s.len);
-    write(STDOUT_FILENO, "\n", 1);
+    check("aes128_encrypt", mln_aes_encrypt(&a, s.data) == 0);
+    check("aes128_ciphertext_differs", memcmp(s.data, saved, 16) != 0);
+    check("aes128_decrypt", mln_aes_decrypt(&a, s.data) == 0);
+    check("aes128_roundtrip", memcmp(s.data, saved, 16) == 0);
+}
 
-    if (mln_aes_decrypt(&a, s.data) < 0) {
-        fprintf(stderr, "aes decrypt failed\n");
-        return -1;
-    }
-    write(STDOUT_FILENO, s.data, s.len);
-    write(STDOUT_FILENO, "\n", 1);
+/* Test AES-192 basic encrypt/decrypt roundtrip */
+static void test_aes192_roundtrip(void)
+{
+    mln_aes_t a;
+    mln_u8_t text[16] = "TestAES192Block!";
+    mln_u8_t saved[16];
 
-    return 0;
+    memcpy(saved, text, 16);
+
+    check("aes192_init", mln_aes_init(&a, (mln_u8ptr_t)"abcdefghijklmnopqrstuvwx", M_AES_192) == 0);
+    check("aes192_encrypt", mln_aes_encrypt(&a, text) == 0);
+    check("aes192_ciphertext_differs", memcmp(text, saved, 16) != 0);
+    check("aes192_decrypt", mln_aes_decrypt(&a, text) == 0);
+    check("aes192_roundtrip", memcmp(text, saved, 16) == 0);
+}
+
+/* Test AES-256 basic encrypt/decrypt roundtrip */
+static void test_aes256_roundtrip(void)
+{
+    mln_aes_t a;
+    mln_u8_t text[16] = "TestAES256Block!";
+    mln_u8_t saved[16];
+
+    memcpy(saved, text, 16);
+
+    check("aes256_init", mln_aes_init(&a, (mln_u8ptr_t)"abcdefghijklmnopqrstuvwxyz012345", M_AES_256) == 0);
+    check("aes256_encrypt", mln_aes_encrypt(&a, text) == 0);
+    check("aes256_ciphertext_differs", memcmp(text, saved, 16) != 0);
+    check("aes256_decrypt", mln_aes_decrypt(&a, text) == 0);
+    check("aes256_roundtrip", memcmp(text, saved, 16) == 0);
+}
+
+/* Test invalid bits parameter */
+static void test_invalid_bits(void)
+{
+    mln_aes_t a;
+    check("invalid_bits_3", mln_aes_init(&a, (mln_u8ptr_t)"abcdefghijklmnop", 3) < 0);
+    check("invalid_bits_99", mln_aes_init(&a, (mln_u8ptr_t)"abcdefghijklmnop", 99) < 0);
+}
+
+/* Test that same key+plaintext always produces same ciphertext (determinism) */
+static void test_determinism(void)
+{
+    mln_aes_t a;
+    mln_u8_t text1[16] = "DeterministicTst";
+    mln_u8_t text2[16] = "DeterministicTst";
+
+    mln_aes_init(&a, (mln_u8ptr_t)"abcdefghijklmnop", M_AES_128);
+    mln_aes_encrypt(&a, text1);
+    mln_aes_encrypt(&a, text2);
+    check("determinism", memcmp(text1, text2, 16) == 0);
+}
+
+/* Test that different keys produce different ciphertext */
+static void test_different_keys(void)
+{
+    mln_aes_t a1, a2;
+    mln_u8_t text1[16] = "SameTextDiffKey!";
+    mln_u8_t text2[16] = "SameTextDiffKey!";
+
+    mln_aes_init(&a1, (mln_u8ptr_t)"aaaaaaaaaaaaaaaa", M_AES_128);
+    mln_aes_init(&a2, (mln_u8ptr_t)"bbbbbbbbbbbbbbbb", M_AES_128);
+    mln_aes_encrypt(&a1, text1);
+    mln_aes_encrypt(&a2, text2);
+    check("different_keys_different_cipher", memcmp(text1, text2, 16) != 0);
+}
+
+/* Test that different plaintexts produce different ciphertexts */
+static void test_different_plaintexts(void)
+{
+    mln_aes_t a;
+    mln_u8_t text1[16] = "PlaintextAAAAA01";
+    mln_u8_t text2[16] = "PlaintextBBBBB02";
+
+    mln_aes_init(&a, (mln_u8ptr_t)"abcdefghijklmnop", M_AES_128);
+    mln_aes_encrypt(&a, text1);
+    mln_aes_encrypt(&a, text2);
+    check("different_plaintexts_different_cipher", memcmp(text1, text2, 16) != 0);
+}
+
+/* Test all-zero plaintext and all-zero key */
+static void test_zero_data(void)
+{
+    mln_aes_t a;
+    mln_u8_t key[16];
+    mln_u8_t text[16];
+    mln_u8_t saved[16];
+
+    memset(key, 0, 16);
+    memset(text, 0, 16);
+    memset(saved, 0, 16);
+
+    mln_aes_init(&a, key, M_AES_128);
+    mln_aes_encrypt(&a, text);
+    check("zero_encrypt_changes", memcmp(text, saved, 16) != 0);
+    mln_aes_decrypt(&a, text);
+    check("zero_roundtrip", memcmp(text, saved, 16) == 0);
+}
+
+/* Test all-0xff plaintext and key */
+static void test_allff_data(void)
+{
+    mln_aes_t a;
+    mln_u8_t key[16];
+    mln_u8_t text[16];
+    mln_u8_t saved[16];
+
+    memset(key, 0xff, 16);
+    memset(text, 0xff, 16);
+    memset(saved, 0xff, 16);
+
+    mln_aes_init(&a, key, M_AES_128);
+    mln_aes_encrypt(&a, text);
+    check("allff_encrypt_changes", memcmp(text, saved, 16) != 0);
+    mln_aes_decrypt(&a, text);
+    check("allff_roundtrip", memcmp(text, saved, 16) == 0);
+}
+
+/* Test mln_aes_new / mln_aes_free (heap allocation) */
+static void test_new_free(void)
+{
+    mln_aes_t *a;
+    mln_u8_t text[16] = "HeapAllocTest!XY";
+    mln_u8_t saved[16];
+
+    memcpy(saved, text, 16);
+
+    a = mln_aes_new((mln_u8ptr_t)"abcdefghijklmnop", M_AES_128);
+    check("aes_new_not_null", a != NULL);
+    if (a != NULL) {
+        mln_aes_encrypt(a, text);
+        check("aes_new_encrypt_changes", memcmp(text, saved, 16) != 0);
+        mln_aes_decrypt(a, text);
+        check("aes_new_roundtrip", memcmp(text, saved, 16) == 0);
+        mln_aes_free(a);
+    }
+
+    /* mln_aes_free(NULL) should not crash */
+    mln_aes_free(NULL);
+    check("aes_free_null_safe", 1);
+}
+
+/* Test multiple blocks encryption (simulating ECB mode) */
+static void test_multiple_blocks(void)
+{
+    mln_aes_t a;
+    mln_u8_t data[48] = "Block1__16bytes!Block2__16bytes!Block3__16bytes!";
+    mln_u8_t saved[48];
+    int i;
+
+    memcpy(saved, data, 48);
+    mln_aes_init(&a, (mln_u8ptr_t)"abcdefghijklmnop", M_AES_128);
+
+    for (i = 0; i < 48; i += 16)
+        mln_aes_encrypt(&a, data + i);
+
+    check("multiblock_encrypted", memcmp(data, saved, 48) != 0);
+
+    for (i = 0; i < 48; i += 16)
+        mln_aes_decrypt(&a, data + i);
+
+    check("multiblock_roundtrip", memcmp(data, saved, 48) == 0);
+}
+
+/* Test cross-key-size: encrypt with one size, verify cannot decrypt with different size */
+static void test_cross_key_mismatch(void)
+{
+    mln_aes_t a128, a256;
+    mln_u8_t text[16] = "CrossKeyMismatch";
+    mln_u8_t saved[16];
+
+    memcpy(saved, text, 16);
+    mln_aes_init(&a128, (mln_u8ptr_t)"abcdefghijklmnop", M_AES_128);
+    mln_aes_init(&a256, (mln_u8ptr_t)"abcdefghijklmnopqrstuvwxyz012345", M_AES_256);
+
+    mln_aes_encrypt(&a128, text);
+    mln_aes_decrypt(&a256, text);
+    check("cross_key_mismatch_no_roundtrip", memcmp(text, saved, 16) != 0);
+}
+
+/* Test known AES-128 test vector (NIST FIPS 197 Appendix B) */
+static void test_nist_vector(void)
+{
+    mln_aes_t a;
+    mln_u8_t key[16], text[16], expected[16];
+
+    /* NIST FIPS 197 Appendix B */
+    hex2bin("2b7e151628aed2a6abf7158809cf4f3c", key, 16);
+    hex2bin("3243f6a8885a308d313198a2e0370734", text, 16);
+    hex2bin("3925841d02dc09fbdc118597196a0b32", expected, 16);
+
+    mln_aes_init(&a, key, M_AES_128);
+    mln_aes_encrypt(&a, text);
+    check("nist_aes128_encrypt", memcmp(text, expected, 16) == 0);
+
+    mln_aes_decrypt(&a, text);
+    hex2bin("3243f6a8885a308d313198a2e0370734", expected, 16);
+    check("nist_aes128_decrypt", memcmp(text, expected, 16) == 0);
+}
+
+/* Test re-initialization with different key */
+static void test_reinit(void)
+{
+    mln_aes_t a;
+    mln_u8_t text1[16] = "ReinitTestData01";
+    mln_u8_t text2[16] = "ReinitTestData01";
+    mln_u8_t saved[16];
+
+    memcpy(saved, text1, 16);
+
+    mln_aes_init(&a, (mln_u8ptr_t)"key1key1key1key1", M_AES_128);
+    mln_aes_encrypt(&a, text1);
+
+    mln_aes_init(&a, (mln_u8ptr_t)"key2key2key2key2", M_AES_128);
+    mln_aes_encrypt(&a, text2);
+
+    check("reinit_different_output", memcmp(text1, text2, 16) != 0);
+
+    mln_aes_decrypt(&a, text2);
+    check("reinit_roundtrip_key2", memcmp(text2, saved, 16) == 0);
+}
+
+/* Test double encrypt and double decrypt */
+static void test_double_encrypt(void)
+{
+    mln_aes_t a;
+    mln_u8_t text[16] = "DoubleEncDecTest";
+    mln_u8_t saved[16];
+
+    memcpy(saved, text, 16);
+    mln_aes_init(&a, (mln_u8ptr_t)"abcdefghijklmnop", M_AES_128);
+
+    mln_aes_encrypt(&a, text);
+    mln_aes_encrypt(&a, text);
+    mln_aes_decrypt(&a, text);
+    mln_aes_decrypt(&a, text);
+
+    check("double_encrypt_decrypt_roundtrip", memcmp(text, saved, 16) == 0);
+}
+
+int main(int argc, char *argv[])
+{
+    test_aes128_roundtrip();
+    test_aes192_roundtrip();
+    test_aes256_roundtrip();
+    test_invalid_bits();
+    test_determinism();
+    test_different_keys();
+    test_different_plaintexts();
+    test_zero_data();
+    test_allff_data();
+    test_new_free();
+    test_multiple_blocks();
+    test_cross_key_mismatch();
+    test_nist_vector();
+    test_reinit();
+    test_double_encrypt();
+
+    printf("\nAES Tests: %d passed, %d failed, %d total\n",
+           pass_count, fail_count, test_count);
+
+    return fail_count > 0 ? 1 : 0;
 }


### PR DESCRIPTION
Replace byte-by-byte SubBytes/ShiftRows/MixColumns with precomputed T-table lookups (Te0-Te3/Td0-Td3) and column-major state layout. Add precomputed InvMixColumns decryption key schedule (dw[60]). Achieves 5-10x speedup across AES-128/192/256 encrypt and decrypt.

Expand t/aes.c from basic roundtrip to 36 tests covering all key sizes, NIST test vectors, edge cases, heap allocation, multi-block, cross-key mismatch, re-initialization and double encrypt/decrypt.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
[https://github.com/Water-Melon/Melon/blob/master/CONTRIBUTING.md#contributing](https://github.com/Water-Melon/Melon/blob/master/CONTRIBUTING.md#contributing)
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
