### PR TITLE
perf(chain,connection,http,websocket): optimize I/O pipeline with FNV-1a hash, zero-copy parsing, and RFC 6455 compliance (#46)

### DIFF
--- a/docs/book/cn/tcp_io.md
+++ b/docs/book/cn/tcp_io.md
@@ -120,6 +120,18 @@ mln_chain_t *mln_chain_new(mln_alloc_t *pool);
 
 
 
+#### mln_chain_new_with_buf
+
+```c
+mln_chain_t *mln_chain_new_with_buf(mln_alloc_t *pool);
+```
+
+描述：从内存池`pool`中创建链结构，并为其分配一个`buf`结构。相当于先调用`mln_chain_new`再调用`mln_buf_new`的便捷函数。
+
+返回值：成功则返回链结构指针（其`buf`成员已被初始化），否则返回`NULL`
+
+
+
 #### mln_buf_pool_release
 
 ```c
@@ -301,6 +313,34 @@ int mln_tcp_conn_recv(mln_tcp_conn_t *tc, mln_u32_t flag);
 
 
 
+#### mln_tcp_conn_move_sent
+
+```c
+void mln_tcp_conn_move_sent(mln_tcp_conn_t *tc);
+```
+
+描述：将发送队列（send queue）中的所有链节点一次性移至已发送队列（sent queue）。移动后发送队列为空。此操作不释放任何资源，仅调整队列指针。
+
+返回值：无
+
+
+
+#### mln_tcp_conn_send_chain
+
+```c
+int mln_tcp_conn_send_chain(mln_tcp_conn_t *tc, mln_chain_t *chain);
+```
+
+描述：将`chain`追加到`tc`的发送队列后立刻调用`mln_tcp_conn_send`进行发送。是`mln_tcp_conn_append` + `mln_tcp_conn_send`的便捷函数。
+
+返回值：与`mln_tcp_conn_send`一致：
+
+- `M_C_FINISH`表示发送完成
+- `M_C_NOTYET`表示还有数据未发完
+- `M_C_ERROR`表示发送失败
+
+
+
 #### mln_tcp_conn_send_empty
 
 ```c
@@ -352,12 +392,24 @@ mln_tcp_conn_fd_get(pconn)
 #### mln_tcp_conn_fd_set
 
 ```c
-mln_tcp_conn_fd_set(pconn,fd)
+void mln_tcp_conn_fd_set(mln_tcp_conn_t *tc, int fd);
 ```
 
-描述：设置TCP结构中的套接字描述符为`fd`。
+描述：设置TCP结构中的套接字描述符为`fd`，并自动更新非阻塞标志位。
 
 返回值：无
+
+
+
+#### mln_tcp_conn_set_nonblock
+
+```c
+int mln_tcp_conn_set_nonblock(mln_tcp_conn_t *tc, int nb);
+```
+
+描述：设置或清除TCP连接的非阻塞模式。`nb`为非零值表示设置为非阻塞，为`0`表示设置为阻塞。本函数会通过`fcntl`更新底层套接字标志并同步`tc`内的`nonblock`标志位。
+
+返回值：成功则返回`0`，失败返回`-1`
 
 
 

--- a/docs/book/en/tcp_io.md
+++ b/docs/book/en/tcp_io.md
@@ -118,6 +118,18 @@ Return value: If successful, return the chain structure pointer, otherwise retur
 
 
 
+#### mln_chain_new_with_buf
+
+```c
+mln_chain_t *mln_chain_new_with_buf(mln_alloc_t *pool);
+```
+
+Description: Create a chain structure from the memory pool `pool` and allocate a `buf` structure for it. This is a convenience function equivalent to calling `mln_chain_new` followed by `mln_buf_new`.
+
+Return value: If successful, return the chain structure pointer (with its `buf` member initialized), otherwise return `NULL`
+
+
+
 #### mln_buf_pool_release
 
 ```c
@@ -299,6 +311,34 @@ return value:
 
 
 
+#### mln_tcp_conn_move_sent
+
+```c
+void mln_tcp_conn_move_sent(mln_tcp_conn_t *tc);
+```
+
+Description: Move all chain nodes from the send queue to the sent queue in one operation. After this call the send queue is empty. This operation does not release any resources, it only adjusts the queue pointers.
+
+Return value: none
+
+
+
+#### mln_tcp_conn_send_chain
+
+```c
+int mln_tcp_conn_send_chain(mln_tcp_conn_t *tc, mln_chain_t *chain);
+```
+
+Description: Append `chain` to the send queue of `tc` and immediately call `mln_tcp_conn_send` to send. This is a convenience function combining `mln_tcp_conn_append` and `mln_tcp_conn_send`.
+
+Return value: Same as `mln_tcp_conn_send`:
+
+- `M_C_FINISH` indicates that the transmission is completed
+- `M_C_NOTYET` indicates that there is still data to be sent
+- `M_C_ERROR` means sending failed
+
+
+
 #### mln_tcp_conn_send_empty
 
 ```c
@@ -350,12 +390,24 @@ Return value: socket descriptor
 #### mln_tcp_conn_fd_set
 
 ```c
-mln_tcp_conn_fd_set(pconn,fd)
+void mln_tcp_conn_fd_set(mln_tcp_conn_t *tc, int fd);
 ```
 
-Description: Set the socket descriptor in the TCP structure to `fd`.
+Description: Set the socket descriptor in the TCP structure to `fd` and automatically update the non-blocking flag.
 
 Return value: none
+
+
+
+#### mln_tcp_conn_set_nonblock
+
+```c
+int mln_tcp_conn_set_nonblock(mln_tcp_conn_t *tc, int nb);
+```
+
+Description: Set or clear the non-blocking mode on the TCP connection. A non-zero `nb` sets non-blocking mode, `0` sets blocking mode. This function updates the underlying socket flags via `fcntl` and synchronizes the `nonblock` flag in `tc`.
+
+Return value: return `0` on success, `-1` on failure
 
 
 

--- a/include/mln_chain.h
+++ b/include/mln_chain.h
@@ -58,8 +58,29 @@ typedef struct mln_chain_s {
     }\
 }
 
-extern mln_buf_t *mln_buf_new(mln_alloc_t *pool);
+/*
+ * Inline mln_buf_new for performance - avoids function call overhead
+ * on the hot allocation path.
+ */
+static inline mln_buf_t *mln_buf_new(mln_alloc_t *pool)
+{
+    mln_buf_t *b = mln_alloc_m(pool, sizeof(mln_buf_t));
+    if (b == NULL) return NULL;
+    b->left_pos = b->pos = b->last = NULL;
+    b->start = b->end = NULL;
+    b->shadow = NULL;
+    b->file_left_pos = b->file_pos = b->file_last = 0;
+    b->file = NULL;
+    b->temporary = b->in_memory = b->in_file = 0;
+#if !defined(MSVC) && defined(MLN_MMAP)
+    b->mmap = 0;
+#endif
+    b->flush = b->sync = b->last_buf = b->last_in_chain = 0;
+    return b;
+}
+
 extern mln_chain_t *mln_chain_new(mln_alloc_t *pool);
+extern mln_chain_t *mln_chain_new_with_buf(mln_alloc_t *pool);
 extern void mln_buf_pool_release(mln_buf_t *b);
 extern void mln_chain_pool_release(mln_chain_t *c);
 extern void mln_chain_pool_release_all(mln_chain_t *c);

--- a/include/mln_chain.h
+++ b/include/mln_chain.h
@@ -6,6 +6,7 @@
 #ifndef __MLN_CHAIN_H
 #define __MLN_CHAIN_H
 
+#include <string.h>
 #include "mln_types.h"
 #include "mln_string.h"
 #include "mln_alloc.h"
@@ -66,6 +67,7 @@ static inline mln_buf_t *mln_buf_new(mln_alloc_t *pool)
 {
     mln_buf_t *b = mln_alloc_m(pool, sizeof(mln_buf_t));
     if (b == NULL) return NULL;
+    memset(b, 0, sizeof(mln_buf_t));
     b->left_pos = b->pos = b->last = NULL;
     b->start = b->end = NULL;
     b->shadow = NULL;

--- a/include/mln_connection.h
+++ b/include/mln_connection.h
@@ -51,9 +51,9 @@ typedef struct {
 #define mln_tcp_conn_recv_empty(pconn) ((pconn)->rcv_head == NULL)
 #define mln_tcp_conn_sent_empty(pconn) ((pconn)->sent_head == NULL)
 #define mln_tcp_conn_fd_get(pconn) ((pconn)->sockfd)
-#define mln_tcp_conn_fd_set(pconn,fd) (pconn)->sockfd = (fd)
+extern void mln_tcp_conn_fd_set(mln_tcp_conn_t *tc, int fd) __NONNULL1(1);
 #define mln_tcp_conn_pool_get(pconn) ((pconn)->pool)
-#define mln_tcp_conn_set_nonblock(pconn,nb) (pconn)->nonblock = (nb)
+extern int mln_tcp_conn_set_nonblock(mln_tcp_conn_t *tc, int nb) __NONNULL1(1);
 extern int mln_tcp_conn_init(mln_tcp_conn_t *tc, int sockfd) __NONNULL1(1);
 extern void mln_tcp_conn_destroy(mln_tcp_conn_t *tc);
 extern void

--- a/include/mln_connection.h
+++ b/include/mln_connection.h
@@ -43,6 +43,7 @@ typedef struct {
     mln_chain_t *sent_head;
     mln_chain_t *sent_tail;
     int          sockfd;
+    mln_u32_t    nonblock:1;
 } mln_tcp_conn_t;
 
 
@@ -52,6 +53,7 @@ typedef struct {
 #define mln_tcp_conn_fd_get(pconn) ((pconn)->sockfd)
 #define mln_tcp_conn_fd_set(pconn,fd) (pconn)->sockfd = (fd)
 #define mln_tcp_conn_pool_get(pconn) ((pconn)->pool)
+#define mln_tcp_conn_set_nonblock(pconn,nb) (pconn)->nonblock = (nb)
 extern int mln_tcp_conn_init(mln_tcp_conn_t *tc, int sockfd) __NONNULL1(1);
 extern void mln_tcp_conn_destroy(mln_tcp_conn_t *tc);
 extern void
@@ -67,6 +69,8 @@ extern mln_chain_t *mln_tcp_conn_pop(mln_tcp_conn_t *tc, int type) __NONNULL1(1)
 extern mln_chain_t *mln_tcp_conn_tail(mln_tcp_conn_t *tc, int type) __NONNULL1(1);
 extern int mln_tcp_conn_send(mln_tcp_conn_t *tc) __NONNULL1(1);
 extern int mln_tcp_conn_recv(mln_tcp_conn_t *tc, mln_u32_t flag) __NONNULL1(1);
+extern void mln_tcp_conn_move_sent(mln_tcp_conn_t *tc) __NONNULL1(1);
+extern int mln_tcp_conn_send_chain(mln_tcp_conn_t *tc, mln_chain_t *chain) __NONNULL2(1,2);
 
 #endif
 

--- a/include/mln_http.h
+++ b/include/mln_http.h
@@ -11,7 +11,7 @@
 #include "mln_alloc.h"
 
 #define M_HTTP_HASH_LEN                        31
-#define M_HTTP_GENERATE_ALLOC_SIZE             1024
+#define M_HTTP_GENERATE_ALLOC_SIZE             4096
 
 /*http type*/
 #define M_HTTP_UNKNOWN                         0

--- a/include/mln_websocket.h
+++ b/include/mln_websocket.h
@@ -161,5 +161,9 @@ extern int mln_websocket_ping_generate(mln_websocket_t *ws, mln_chain_t **out_cn
 extern int mln_websocket_pong_generate(mln_websocket_t *ws, mln_chain_t **out_cnode, mln_u32_t flags) __NONNULL2(1,2);
 extern int mln_websocket_generate(mln_websocket_t *ws, mln_chain_t **out_cnode) __NONNULL1(1);
 extern int mln_websocket_parse(mln_websocket_t *ws, mln_chain_t **in) __NONNULL1(1);
+/*
+ * These are internal helpers, not part of the public API.
+ * They are declared static in mln_websocket.c.
+ */
 
 #endif

--- a/src/mln_chain.c
+++ b/src/mln_chain.c
@@ -6,26 +6,21 @@
 #include "mln_chain.h"
 #include "mln_func.h"
 
-mln_buf_t *mln_buf_new(mln_alloc_t *pool)
-{
-    mln_buf_t *b = mln_alloc_m(pool, sizeof(mln_buf_t));
-    b->left_pos = b->pos = b->last = NULL;
-    b->start = b->end = NULL;
-    b->shadow = NULL;
-    b->file_left_pos = b->file_pos = b->file_last = 0;
-    b->file = NULL;
-    b->temporary = b->in_memory = b->in_file = 0;
-#if !defined(MSVC) && defined(MLN_MMAP)
-    b->mmap = 0;
-#endif
-    b->flush = b->sync = b->last_buf = b->last_in_chain = 0;
-    return b;
-}
-
 MLN_FUNC(, mln_chain_t *, mln_chain_new, (mln_alloc_t *pool), (pool), {
     mln_chain_t *c = mln_alloc_m(pool, sizeof(mln_chain_t));
     c->buf = NULL;
     c->next = NULL;
+    return c;
+})
+
+MLN_FUNC(, mln_chain_t *, mln_chain_new_with_buf, (mln_alloc_t *pool), (pool), {
+    mln_chain_t *c = mln_chain_new(pool);
+    if (c == NULL) return NULL;
+    c->buf = mln_buf_new(pool);
+    if (c->buf == NULL) {
+        mln_alloc_free(c);
+        return NULL;
+    }
     return c;
 })
 
@@ -84,7 +79,9 @@ MLN_FUNC_VOID(, void, mln_chain_pool_release_all, (mln_chain_t *c), (c), {
     while (c != NULL) {
         fr = c;
         c = c->next;
-        mln_chain_pool_release(fr);
+        if (fr->buf != NULL) {
+            mln_buf_pool_release(fr->buf);
+        }
+        mln_alloc_free(fr);
     }
 })
-

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -53,7 +53,7 @@ static inline int mln_fd_is_nonblock(int fd)
     return 0; /* no useful API for getting this flag from socket */
 #else
     if (fd < 0) return 0;
-    int flg = fcntl(fd, F_GETFL, NULL);
+    int flg = fcntl(fd, F_GETFL, 0);
     if (flg < 0) return 0;
     return (flg & O_NONBLOCK) != 0;
 #endif
@@ -89,7 +89,7 @@ MLN_FUNC(, int, mln_tcp_conn_set_nonblock, (mln_tcp_conn_t *tc, int nb), (tc, nb
         tc->nonblock = nb ? 1 : 0;
         return 0;
     }
-    int flg = fcntl(tc->sockfd, F_GETFL, NULL);
+    int flg = fcntl(tc->sockfd, F_GETFL, 0);
     if (flg < 0) return -1;
     if (nb) {
         if (fcntl(tc->sockfd, F_SETFL, flg | O_NONBLOCK) < 0) return -1;

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -70,6 +70,7 @@ MLN_FUNC(, int, mln_tcp_conn_init, (mln_tcp_conn_t *tc, int sockfd), (tc, sockfd
     tc->snd_head = tc->snd_tail = NULL;
     tc->sent_head = tc->sent_tail = NULL;
     tc->sockfd = sockfd;
+    tc->nonblock = mln_fd_is_nonblock(sockfd);
     return 0;
 })
 
@@ -257,7 +258,7 @@ MLN_FUNC(static inline, int, mln_tcp_conn_send_chain_memory, (mln_tcp_conn_t *tc
     int proc_vec, nvec = 256;
     struct iovec vector[256];
 
-    if (mln_fd_is_nonblock(tc->sockfd)) {
+    if (tc->nonblock) {
         while (1) {
             proc_vec = 0;
             for (c = tc->snd_head; c != NULL; c = c->next) {
@@ -368,14 +369,14 @@ blk:
 #else
 static inline int mln_tcp_conn_send_chain_memory(mln_tcp_conn_t *tc)
 {
-    mln_u8_t buf[8192], *p;
+    mln_u8_t buf[16384], *p;
     mln_chain_t *c;
     mln_buf_t *b;
     mln_size_t left_size;
     register mln_size_t buf_left_size;
     int n, is_done = 0;
 
-    if (mln_fd_is_nonblock(tc->sockfd)) {
+    if (tc->nonblock) {
         while (1) {
             p = buf;
             left_size = sizeof(buf);
@@ -509,7 +510,7 @@ MLN_FUNC(static inline, int, mln_tcp_conn_send_chain_file, (mln_tcp_conn_t *tc),
     mln_buf_t *b;
     mln_size_t buf_left_size;
 
-    if (mln_fd_is_nonblock(sockfd)) {
+    if (tc->nonblock) {
         while ((c = tc->snd_head) != NULL) {
             if ((b = c->buf) == NULL) {
                 c = mln_tcp_conn_pop_inline(tc, M_C_SEND);
@@ -579,10 +580,10 @@ static inline int mln_tcp_conn_send_chain_file(mln_tcp_conn_t *tc)
     int n;
     mln_buf_t *b;
     mln_chain_t *c;
-    mln_u8_t buf[4096];
+    mln_u8_t buf[16384];
     mln_size_t len, buf_left_size;
 
-    if (mln_fd_is_nonblock(sockfd)) {
+    if (tc->nonblock) {
         while ((c = tc->snd_head) != NULL) {
             if ((b = c->buf) == NULL) {
                 c = mln_tcp_conn_pop_inline(tc, M_C_SEND);
@@ -708,12 +709,30 @@ MLN_FUNC(static inline, mln_chain_t *, mln_tcp_conn_pop_inline, \
     return rc;
 })
 
+MLN_FUNC_VOID(, void, mln_tcp_conn_move_sent, (mln_tcp_conn_t *tc), (tc), {
+    if (tc->snd_head == NULL) return;
+
+    if (tc->sent_tail == NULL) {
+        tc->sent_head = tc->snd_head;
+        tc->sent_tail = tc->snd_tail;
+    } else {
+        tc->sent_tail->next = tc->snd_head;
+        tc->sent_tail = tc->snd_tail;
+    }
+    tc->snd_head = tc->snd_tail = NULL;
+})
+
+MLN_FUNC(, int, mln_tcp_conn_send_chain, (mln_tcp_conn_t *tc, mln_chain_t *chain), (tc, chain), {
+    mln_tcp_conn_append_chain(tc, chain, NULL, M_C_SEND);
+    return mln_tcp_conn_send(tc);
+})
+
 MLN_FUNC(, int, mln_tcp_conn_recv, (mln_tcp_conn_t *tc, mln_u32_t flag), (tc, flag), {
     ASSERT(flag == M_C_TYPE_MEMORY || flag == M_C_TYPE_FILE);
 
     int n;
 
-    if (mln_fd_is_nonblock(tc->sockfd)) {
+    if (tc->nonblock) {
 goon_non:
         while ((n = mln_tcp_conn_recv_chain(tc, flag)) > 0) {
             /*do nothing*/
@@ -730,7 +749,7 @@ goon_blk:
     }
 
     if (errno == EINTR) {
-        if (mln_fd_is_nonblock(tc->sockfd)) {
+        if (tc->nonblock) {
             goto goon_non;
         } else {
             goto goon_blk;
@@ -784,7 +803,7 @@ MLN_FUNC(static inline, int, mln_tcp_conn_recv_chain, \
 static inline int mln_tcp_conn_recv_chain_file(int sockfd, mln_alloc_t *pool, mln_buf_t *b, mln_buf_t *last)
 {
     int n;
-    mln_u8_t buf[1024];
+    mln_u8_t buf[8192];
 
 #if defined(MSVC)
     n = recv(sockfd, (char *)buf, sizeof(buf), 0);
@@ -819,16 +838,16 @@ static inline int mln_tcp_conn_recv_chain_mem(int sockfd, mln_alloc_t *pool, mln
     mln_u8ptr_t buf;
     int n;
 
-    buf = (mln_u8ptr_t)mln_alloc_m(pool, 1024);
+    buf = (mln_u8ptr_t)mln_alloc_m(pool, 4096);
     if (buf == NULL) {
         errno = ENOMEM;
         return -1;
     }
 
 #if defined(MSVC)
-    n = recv(sockfd, (char *)buf, 1024, 0);
+    n = recv(sockfd, (char *)buf, 4096, 0);
 #else
-    n = recv(sockfd, buf, 1024, 0);
+    n = recv(sockfd, buf, 4096, 0);
 #endif
     if (n <= 0) {
         mln_alloc_free(buf);

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -75,6 +75,33 @@ MLN_FUNC(, int, mln_tcp_conn_init, (mln_tcp_conn_t *tc, int sockfd), (tc, sockfd
     return 0;
 })
 
+MLN_FUNC_VOID(, void, mln_tcp_conn_fd_set, (mln_tcp_conn_t *tc, int fd), (tc, fd), {
+    tc->sockfd = fd;
+    tc->nonblock = mln_fd_is_nonblock(fd);
+})
+
+MLN_FUNC(, int, mln_tcp_conn_set_nonblock, (mln_tcp_conn_t *tc, int nb), (tc, nb), {
+#if defined(MSVC)
+    tc->nonblock = 0;
+    return 0;
+#else
+    if (tc->sockfd < 0) {
+        tc->nonblock = nb ? 1 : 0;
+        return 0;
+    }
+    int flg = fcntl(tc->sockfd, F_GETFL, NULL);
+    if (flg < 0) return -1;
+    if (nb) {
+        if (fcntl(tc->sockfd, F_SETFL, flg | O_NONBLOCK) < 0) return -1;
+        tc->nonblock = 1;
+    } else {
+        if (fcntl(tc->sockfd, F_SETFL, flg & ~O_NONBLOCK) < 0) return -1;
+        tc->nonblock = 0;
+    }
+    return 0;
+#endif
+})
+
 MLN_FUNC_VOID(, void, mln_tcp_conn_destroy, (mln_tcp_conn_t *tc), (tc), {
     if (tc == NULL) return;
 

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -52,9 +52,10 @@ static inline int mln_fd_is_nonblock(int fd)
 #if defined(MSVC)
     return 0; /* no useful API for getting this flag from socket */
 #else
+    if (fd < 0) return 0;
     int flg = fcntl(fd, F_GETFL, NULL);
-    ASSERT(flg >= 0);
-    return flg & O_NONBLOCK;
+    if (flg < 0) return 0;
+    return (flg & O_NONBLOCK) != 0;
 #endif
 }
 

--- a/src/mln_http.c
+++ b/src/mln_http.c
@@ -123,6 +123,27 @@ mln_http_map_t mln_http_status[] = {
 {mln_string("Unparseable Response Headers"),    mln_string("600"), M_HTTP_UNPARSEABLE_RESPONSE_HEADERS}
 };
 
+/* Fast lookup table for common status codes */
+static struct {
+    mln_u32_t code;
+    mln_http_map_t *map_entry;
+} mln_http_status_lookup_table[] = {
+    {M_HTTP_CONTINUE, &mln_http_status[0]},
+    {M_HTTP_OK, &mln_http_status[3]},
+    {M_HTTP_CREATED, &mln_http_status[4]},
+    {M_HTTP_NO_CONTENT, &mln_http_status[7]},
+    {M_HTTP_MOVED_PERMANENTLY, &mln_http_status[11]},
+    {M_HTTP_MOVED_TEMPORARILY, &mln_http_status[12]},
+    {M_HTTP_BAD_REQUEST, &mln_http_status[18]},
+    {M_HTTP_UNAUTHORIZED, &mln_http_status[19]},
+    {M_HTTP_FORBIDDEN, &mln_http_status[21]},
+    {M_HTTP_NOT_FOUND, &mln_http_status[22]},
+    {M_HTTP_INTERNAL_SERVER_ERROR, &mln_http_status[43]},
+    {M_HTTP_NOT_IMPLEMENTED, &mln_http_status[44]},
+    {M_HTTP_BAD_GATEWAY, &mln_http_status[45]},
+    {M_HTTP_SERVICE_UNAVAILABLE, &mln_http_status[46]},
+};
+
 
 MLN_FUNC(, int, mln_http_parse, (mln_http_t *http, mln_chain_t **in), (http, in), {
     if (http == NULL) return M_HTTP_RET_ERROR;
@@ -160,15 +181,18 @@ MLN_FUNC(static inline, int, mln_http_line_length, \
             in = in->next;
             continue;
         }
-        for (p = b->left_pos, end = b->last; p < end; ++p) {
-            if (*p == (mln_u8_t)'\n') break;
-            ++length;
+        /* Use memchr for fast newline search instead of byte-by-byte loop */
+        end = b->last;
+        p = (mln_u8ptr_t)memchr((void *)b->left_pos, '\n', end - b->left_pos);
+        if (p != NULL) {
+            /* Found newline in this buffer */
+            length += (p - b->left_pos);
+            *len = length;
+            return M_HTTP_RET_DONE;
         }
-        if (p >= end) {
-            in = in->next;
-            continue;
-        }
-        break;
+        /* Newline not found, count all remaining bytes and continue */
+        length += (end - b->left_pos);
+        in = in->next;
     }
     if (in == NULL) return M_HTTP_RET_OK;
 
@@ -183,10 +207,50 @@ MLN_FUNC(static inline, int, mln_http_process_line, \
     int ret;
     mln_buf_t *b;
     mln_chain_t *c;
-    mln_u8ptr_t buf, p, last;
+    mln_u8ptr_t buf, p, last, line_buf;
     mln_alloc_t *pool = mln_http_pool_get(http);
     mln_u32_t type = mln_http_type_get(http);
+    mln_size_t actual_len = len;
+    int need_free = 1;
 
+    /* Fast path: Check if line fits in a single buffer without allocation */
+    c = *in;
+    if (c != NULL) {
+        b = c->buf;
+        if (b != NULL && !b->in_file && mln_buf_left_size(b) > 0) {
+            mln_u8ptr_t end = b->last;
+            mln_u8ptr_t newline_pos = (mln_u8ptr_t)memchr((void *)b->left_pos, '\n', end - b->left_pos);
+
+            if (newline_pos != NULL && newline_pos - b->left_pos == len) {
+                /* Line is entirely in this buffer - zero-copy path */
+                line_buf = b->left_pos;
+                need_free = 0;
+
+                /* Skip past the newline */
+                b->left_pos = newline_pos + 1;
+
+                /* Handle CRLF by checking for \r before \n */
+                if (actual_len > 0 && line_buf[actual_len - 1] == '\r') {
+                    actual_len--;
+                }
+
+                /* Check for empty line (signals end of headers) */
+                if (actual_len == 0) {
+                    mln_http_done_set(http, 1);
+                    return M_HTTP_RET_OK;
+                }
+
+                if (type == M_HTTP_UNKNOWN) {
+                    ret = mln_http_parse_headline(http, line_buf, actual_len);
+                } else {
+                    ret = mln_http_parse_field(http, line_buf, actual_len);
+                }
+                return ret;
+            }
+        }
+    }
+
+    /* Slow path: allocate buffer for multi-buffer or complex cases */
     buf = (mln_u8ptr_t)mln_alloc_m(pool, len+1);
     if (buf == NULL) {
         mln_http_error_set(http, M_HTTP_INTERNAL_SERVER_ERROR);
@@ -194,6 +258,7 @@ MLN_FUNC(static inline, int, mln_http_process_line, \
     }
     buf[len] = 0;
     p = buf;
+    line_buf = buf;
 
     while ((c = *in) != NULL) {
         b = c->buf;
@@ -212,27 +277,27 @@ MLN_FUNC(static inline, int, mln_http_process_line, \
         }
     }
 
-    for (last = buf + len - 1; last > buf; --last, --len) {
+    for (last = buf + len - 1; last > buf; --last, --actual_len) {
         if (*last != 0) break;
     }
-    if (len == 0 || (len == 1 && buf[0] == '\r')) {
+    if (actual_len == 0 || (actual_len == 1 && buf[0] == '\r')) {
         mln_alloc_free(buf);
         mln_http_done_set(http, 1);
         return M_HTTP_RET_OK;
     }
 
-    if (buf[len-1] == '\r') {
-        buf[len-1] = 0;
-        --len;
+    if (buf[actual_len-1] == '\r') {
+        buf[actual_len-1] = 0;
+        --actual_len;
     }
 
     if (type == M_HTTP_UNKNOWN) {
-        ret = mln_http_parse_headline(http, buf, len);
+        ret = mln_http_parse_headline(http, buf, actual_len);
     } else {
-        ret = mln_http_parse_field(http, buf, len);
+        ret = mln_http_parse_field(http, buf, actual_len);
     }
 
-    mln_alloc_free(buf);
+    if (need_free) mln_alloc_free(buf);
 
     return ret;
 })
@@ -260,15 +325,24 @@ MLN_FUNC(static inline, int, mln_http_parse_headline, \
             break;
     }
     mln_string_nset(&tmp, buf, p-buf);
-    send = http_version + sizeof(http_version)/sizeof(mln_string_t);
-    for (scan = http_version; scan < send; ++scan) {
-        if (!mln_string_strcasecmp(&tmp, scan)) break;
-    }
-    if (scan < send) {
-        type = M_HTTP_RESPONSE;
-        mln_http_type_set(http, M_HTTP_RESPONSE);
-        mln_http_version_set(http, scan - http_version);
+
+    /* Optimized dispatch: Check for HTTP/x.x version first (starts with "HTTP/") */
+    if (tmp.len >= 5 && (buf[0] == 'H' || buf[0] == 'h') && buf[4] == '/') {
+        /* Fast path for HTTP version strings */
+        send = http_version + sizeof(http_version)/sizeof(mln_string_t);
+        for (scan = http_version; scan < send; ++scan) {
+            if (!mln_string_strcasecmp(&tmp, scan)) break;
+        }
+        if (scan < send) {
+            type = M_HTTP_RESPONSE;
+            mln_http_type_set(http, M_HTTP_RESPONSE);
+            mln_http_version_set(http, scan - http_version);
+        } else {
+            mln_http_error_set(http, M_HTTP_BAD_REQUEST);
+            return M_HTTP_RET_ERROR;
+        }
     } else {
+        /* Check for HTTP methods */
         send = http_method + sizeof(http_method)/sizeof(mln_string_t);
         for (scan = http_method; scan < send; ++scan) {
             if (!mln_string_strcasecmp(&tmp, scan)) break;
@@ -277,7 +351,7 @@ MLN_FUNC(static inline, int, mln_http_parse_headline, \
             type = M_HTTP_REQUEST;
             mln_http_type_set(http, M_HTTP_REQUEST);
             mln_http_method_set(http, scan - http_method);
-        } else { 
+        } else {
             mln_http_error_set(http, M_HTTP_BAD_REQUEST);
             return M_HTTP_RET_ERROR;
         }
@@ -700,15 +774,27 @@ MLN_FUNC(static inline, int, mln_http_generate_version, \
 
 MLN_FUNC(static inline, int, mln_http_generate_status, (struct mln_http_chain_s *hc), (hc), {
     mln_u32_t status = mln_http_status_get(hc->http);
-    mln_http_map_t *map = mln_http_status;
-    mln_http_map_t *end = mln_http_status + sizeof(mln_http_status)/sizeof(mln_http_map_t);
+    mln_http_map_t *map = NULL;
+    int i;
 
-    for (; map < end; ++map) {
-        if (status == map->code) break;
+    /* Fast path: check lookup table for common codes */
+    for (i = 0; i < (int)(sizeof(mln_http_status_lookup_table)/sizeof(mln_http_status_lookup_table[0])); ++i) {
+        if (mln_http_status_lookup_table[i].code == status) {
+            map = mln_http_status_lookup_table[i].map_entry;
+            break;
+        }
     }
-    if (map >= end) {
-        mln_http_error_set(hc->http, M_HTTP_UNPARSEABLE_RESPONSE_HEADERS);
-        return M_HTTP_RET_ERROR;
+
+    /* Fallback: linear scan for uncommon codes */
+    if (map == NULL) {
+        mln_http_map_t *end = mln_http_status + sizeof(mln_http_status)/sizeof(mln_http_map_t);
+        for (map = mln_http_status; map < end; ++map) {
+            if (status == map->code) break;
+        }
+        if (map >= end) {
+            mln_http_error_set(hc->http, M_HTTP_UNPARSEABLE_RESPONSE_HEADERS);
+            return M_HTTP_RET_ERROR;
+        }
     }
 
     if (mln_http_generate_write(hc, map->code_str.data, map->code_str.len) == M_HTTP_RET_ERROR)
@@ -986,12 +1072,18 @@ MLN_FUNC_VOID(static, void, mln_http_hash_free, (void *data), (data), {
 })
 
 MLN_FUNC(static, mln_u64_t, mln_http_hash_calc, (mln_hash_t *h, void *key), (h, key), {
-    mln_u64_t index = 0;
+    /* FNV-1a inspired hash with case-insensitive lowercase normalization */
+    mln_u64_t index = 0x811c9dc5UL;  /* FNV offset basis */
     mln_string_t *s = (mln_string_t *)key;
     mln_u8ptr_t p, end = s->data + s->len;
 
     for (p = s->data; p < end; ++p) {
-        index += (((mln_u64_t)(*p)) * 3);
+        /* Case-insensitive: normalize to lowercase */
+        mln_u8_t c = *p;
+        if (c >= 'A' && c <= 'Z') c += 0x20;
+
+        index ^= c;
+        index *= 0x01000193UL;  /* FNV prime */
     }
 
     return index % h->len;

--- a/src/mln_websocket.c
+++ b/src/mln_websocket.c
@@ -26,6 +26,9 @@ static int mln_websocket_iterate_set_fields(mln_hash_t *h, void *key, void *val,
 static mln_string_t *mln_websocket_client_handshake_key_generate(mln_alloc_t *pool);
 static mln_string_t *mln_websocket_extension_tokens(mln_alloc_t *pool, mln_string_t *in);
 static mln_u32_t mln_websocket_masking_key_generate(void);
+static int mln_websocket_is_valid_status_code(mln_u16_t status);
+static int mln_websocket_is_valid_utf8(mln_u8ptr_t data, mln_size_t len);
+static void mln_websocket_unmask_xor4(mln_u8ptr_t data, mln_size_t len, mln_u32_t masking_key);
 
 MLN_FUNC(, int, mln_websocket_init, (mln_websocket_t *ws, mln_http_t *http), (ws, http), {
     struct mln_hash_attr hattr;
@@ -88,7 +91,7 @@ MLN_FUNC(, mln_websocket_t *, mln_websocket_new, (mln_http_t *http), (http), {
     mln_websocket_t *ws = (mln_websocket_t *)mln_alloc_m(mln_http_pool_get(http), sizeof(mln_websocket_t));
     if (ws == NULL) return NULL;
     if (mln_websocket_init(ws, http) < 0) {
-        free(ws);
+        mln_alloc_free(ws);
         return NULL;
     }
     return ws;
@@ -161,12 +164,13 @@ MLN_FUNC(, int, mln_websocket_validate, (mln_websocket_t *ws), (ws), {
     mln_string_t upgrade_key = mln_string("Upgrade");
     mln_string_t upgrade_val = mln_string("websocket");
     mln_string_t connection_key = mln_string("Connection");
+    mln_string_t upgrade_str = mln_string("Upgrade");
     mln_string_t *tmp;
 
     tmp = mln_http_field_get(http, &upgrade_key);
     if (tmp == NULL || mln_string_strcasecmp(tmp, &upgrade_val)) return M_WS_RET_NOTWS;
     tmp = mln_http_field_get(http, &connection_key);
-    if (tmp == NULL || mln_string_strcasecmp(tmp, &upgrade_key)) return M_WS_RET_NOTWS;
+    if (tmp == NULL || mln_string_strstr(tmp, &upgrade_str) == NULL) return M_WS_RET_NOTWS;
     int ret = mln_websocket_validate_accept(http, ws->key);
     if (ret != M_WS_RET_OK) return ret;
     if (mln_http_type_get(http) != M_HTTP_RESPONSE) return M_WS_RET_ERROR;
@@ -360,7 +364,7 @@ MLN_FUNC(static, mln_string_t *, mln_websocket_extension_tokens, \
         }
         buf[size++] = ',';
     }
-    buf[--size] = '0';
+    buf[--size] = '\0';
     mln_string_slice_free(array);
     mln_string_free(tmp);
 
@@ -633,6 +637,68 @@ MLN_FUNC(, int, mln_websocket_pong_generate, \
     return mln_websocket_generate(ws, out_cnode);
 })
 
+MLN_FUNC(static, int, mln_websocket_is_valid_status_code, (mln_u16_t status), (status), {
+    if (status >= 1000 && status <= 1003) return 1;
+    if (status == 1004) return 0;
+    if (status == 1005 || status == 1006) return 0;
+    if (status >= 1007 && status <= 1011) return 1;
+    if (status >= 1012 && status <= 1014) return 1;
+    if (status == 1015) return 0;
+    if (status >= 3000 && status <= 3999) return 1;
+    if (status >= 4000 && status <= 4999) return 1;
+    return 0;
+})
+
+MLN_FUNC(static, int, mln_websocket_is_valid_utf8, (mln_u8ptr_t data, mln_size_t len), (data, len), {
+    mln_size_t i = 0;
+    mln_u8_t byte;
+    while (i < len) {
+        byte = data[i];
+        if ((byte & 0x80) == 0) {
+            i += 1;
+        } else if ((byte & 0xE0) == 0xC0) {
+            if (i + 1 >= len) return 0;
+            if ((data[i+1] & 0xC0) != 0x80) return 0;
+            i += 2;
+        } else if ((byte & 0xF0) == 0xE0) {
+            if (i + 2 >= len) return 0;
+            if ((data[i+1] & 0xC0) != 0x80) return 0;
+            if ((data[i+2] & 0xC0) != 0x80) return 0;
+            i += 3;
+        } else if ((byte & 0xF8) == 0xF0) {
+            if (i + 3 >= len) return 0;
+            if ((data[i+1] & 0xC0) != 0x80) return 0;
+            if ((data[i+2] & 0xC0) != 0x80) return 0;
+            if ((data[i+3] & 0xC0) != 0x80) return 0;
+            i += 4;
+        } else {
+            return 0;
+        }
+    }
+    return 1;
+})
+
+MLN_FUNC(static, void, mln_websocket_unmask_xor4, (mln_u8ptr_t data, mln_size_t len, mln_u32_t masking_key), (data, len, masking_key), {
+    mln_size_t i = 0;
+    mln_u8_t tmpkey[4];
+    tmpkey[0] = (masking_key >> 24) & 0xff;
+    tmpkey[1] = (masking_key >> 16) & 0xff;
+    tmpkey[2] = (masking_key >> 8) & 0xff;
+    tmpkey[3] = masking_key & 0xff;
+
+    mln_size_t aligned = len & ~3;
+    mln_u32_t *ptr32 = (mln_u32_t *)data;
+    mln_u32_t *key32 = (mln_u32_t *)tmpkey;
+    mln_size_t j;
+    for (j = 0; j < aligned; j += 4) {
+        ptr32[j/4] ^= *key32;
+    }
+
+    for (i = aligned; i < len; ++i) {
+        data[i] ^= tmpkey[i % 4];
+    }
+})
+
 MLN_FUNC(static, mln_u32_t, mln_websocket_masking_key_generate, (void), (), {
     struct timeval tv;
     mln_uauto_t tmp = (mln_uauto_t)&tv;
@@ -747,8 +813,21 @@ MLN_FUNC(, int, mln_websocket_generate, \
             *p++ = ((mln_websocket_get_status(ws) >> 8) & 0xff) ^ tmpkey[i++%4];
             *p++ = (mln_websocket_get_status(ws) & 0xff) ^ tmpkey[i++%4];
         }
-        for (j = 0; i < clen; ++i, ++j) {
-            *p++ = pc[j] ^ tmpkey[i%4];
+
+        mln_size_t remaining = clen - (opcode == M_WS_OPCODE_CLOSE ? 2 : 0);
+        mln_size_t aligned = remaining & ~3;
+        mln_size_t k;
+        mln_u32_t *ptr32 = (mln_u32_t *)p;
+        mln_u32_t *src32 = (mln_u32_t *)pc;
+        mln_u32_t key32 = m;
+
+        for (k = 0; k < aligned; k += 4) {
+            ptr32[k/4] = src32[k/4] ^ key32;
+        }
+        p += aligned;
+
+        for (j = aligned; j < remaining; ++j) {
+            *p++ = pc[j] ^ tmpkey[j%4];
         }
     } else {
         if (opcode == M_WS_OPCODE_CLOSE) {
@@ -851,6 +930,9 @@ againm:
     }
 
     if (len) {
+        if ((b1 & 0xf) >= M_WS_OPCODE_CLOSE && len > 125) {
+            return M_WS_RET_ERROR;
+        }
         if ((b1&0xf) == M_WS_OPCODE_CLOSE && len > 1) {
             mln_u16_t status = 0;
 
@@ -926,22 +1008,48 @@ againc:
 
     if (mln_websocket_get_maskbit(ws)) {
         mln_u8_t tmpkey[4];
-        mln_u16_t status = mln_websocket_get_status(ws);
+        mln_u16_t close_status = mln_websocket_get_status(ws);
         tmpkey[0] = (masking_key >> 24) & 0xff;
         tmpkey[1] = (masking_key >> 16) & 0xff;
         tmpkey[2] = (masking_key >> 8) & 0xff;
         tmpkey[3] = masking_key & 0xff;
-        i = 0;
-        if (mln_websocket_get_opcode(ws) == M_WS_OPCODE_CLOSE && status != 0) {
-            status = ((((status >> 8) & 0xff) ^ tmpkey[i++%4]) << 8) | (status & 0xff);
-            status = (((status >> 8) & 0xff) << 8) | ((status & 0xff) ^ tmpkey[i++%4]);
-            mln_websocket_set_status(ws, status);
+        if (mln_websocket_get_opcode(ws) == M_WS_OPCODE_CLOSE && close_status != 0) {
+            mln_u16_t unmasked_status = (mln_u16_t)((((close_status >> 8) & 0xff) ^ tmpkey[0]) << 8) | \
+                                        (mln_u16_t)(((close_status & 0xff) ^ tmpkey[1]) & 0xff);
+            if (!mln_websocket_is_valid_status_code(unmasked_status)) {
+                if (content != NULL) mln_alloc_free(content);
+                return M_WS_RET_ERROR;
+            }
+            mln_websocket_set_status(ws, unmasked_status);
         }
-        if (content != NULL) {
-            for (tmp = 0; tmp < len; ++tmp) {
-                content[tmp] ^= tmpkey[i++%4];
+        if (content != NULL && len > 0) {
+            mln_websocket_unmask_xor4(content, len, masking_key);
+        }
+    } else {
+        if ((b1 & 0x40) || (b1 & 0x20) || (b1 & 0x10)) {
+            if (mln_websocket_get_ext_handler(ws) == NULL) {
+                if (content != NULL) mln_alloc_free(content);
+                return M_WS_RET_ERROR;
             }
         }
+        if ((b1 & 0xf) == M_WS_OPCODE_CLOSE && mln_websocket_get_status(ws) != 0) {
+            if (!mln_websocket_is_valid_status_code(mln_websocket_get_status(ws))) {
+                if (content != NULL) mln_alloc_free(content);
+                return M_WS_RET_ERROR;
+            }
+        }
+    }
+
+    if ((b1 & 0xf) == M_WS_OPCODE_TEXT && content != NULL && len > 0) {
+        if (!mln_websocket_is_valid_utf8(content, len)) {
+            if (content != NULL) mln_alloc_free(content);
+            return M_WS_RET_ERROR;
+        }
+    }
+
+    if ((b1 & 0xf) >= M_WS_OPCODE_CLOSE && !mln_websocket_get_fin(ws)) {
+        if (content != NULL) mln_alloc_free(content);
+        return M_WS_RET_ERROR;
     }
 
     if (mln_websocket_get_ext_handler(ws) != NULL) {

--- a/src/mln_websocket.c
+++ b/src/mln_websocket.c
@@ -819,7 +819,8 @@ MLN_FUNC(, int, mln_websocket_generate, \
         mln_size_t k;
         mln_u32_t *ptr32 = (mln_u32_t *)p;
         mln_u32_t *src32 = (mln_u32_t *)pc;
-        mln_u32_t key32 = m;
+        mln_u32_t key32;
+        memcpy(&key32, tmpkey, 4);
 
         for (k = 0; k < aligned; k += 4) {
             ptr32[k/4] = src32[k/4] ^ key32;

--- a/src/mln_websocket.c
+++ b/src/mln_websocket.c
@@ -157,6 +157,8 @@ MLN_FUNC(, int, mln_websocket_is_websocket, (mln_http_t *http), (http), {
     return M_WS_RET_OK;
 })
 
+static int mln_websocket_conn_has_upgrade_token(mln_string_t *val);
+
 MLN_FUNC(, int, mln_websocket_validate, (mln_websocket_t *ws), (ws), {
     mln_http_t *http = ws->http;
     if (mln_http_status_get(http) != M_HTTP_SWITCHING_PROTOCOLS) return M_WS_RET_NOTWS;
@@ -164,13 +166,12 @@ MLN_FUNC(, int, mln_websocket_validate, (mln_websocket_t *ws), (ws), {
     mln_string_t upgrade_key = mln_string("Upgrade");
     mln_string_t upgrade_val = mln_string("websocket");
     mln_string_t connection_key = mln_string("Connection");
-    mln_string_t upgrade_str = mln_string("Upgrade");
     mln_string_t *tmp;
 
     tmp = mln_http_field_get(http, &upgrade_key);
     if (tmp == NULL || mln_string_strcasecmp(tmp, &upgrade_val)) return M_WS_RET_NOTWS;
     tmp = mln_http_field_get(http, &connection_key);
-    if (tmp == NULL || mln_string_strstr(tmp, &upgrade_str) == NULL) return M_WS_RET_NOTWS;
+    if (tmp == NULL || !mln_websocket_conn_has_upgrade_token(tmp)) return M_WS_RET_NOTWS;
     int ret = mln_websocket_validate_accept(http, ws->key);
     if (ret != M_WS_RET_OK) return ret;
     if (mln_http_type_get(http) != M_HTTP_RESPONSE) return M_WS_RET_ERROR;
@@ -637,9 +638,29 @@ MLN_FUNC(, int, mln_websocket_pong_generate, \
     return mln_websocket_generate(ws, out_cnode);
 })
 
+static int mln_websocket_conn_has_upgrade_token(mln_string_t *val)
+{
+    mln_u8ptr_t p = val->data;
+    mln_u8ptr_t end = val->data + val->len;
+    while (p < end) {
+        while (p < end && (*p == ' ' || *p == '\t')) p++;
+        mln_u8ptr_t tok_start = p;
+        while (p < end && *p != ',') p++;
+        mln_u8ptr_t tok_end = p;
+        while (tok_end > tok_start && (tok_end[-1] == ' ' || tok_end[-1] == '\t')) tok_end--;
+        if ((mln_size_t)(tok_end - tok_start) == 7) {
+            mln_string_t tok;
+            tok.data = tok_start;
+            tok.len = 7;
+            if (!mln_string_const_strcasecmp(&tok, "Upgrade")) return 1;
+        }
+        if (p < end) p++;
+    }
+    return 0;
+}
+
 MLN_FUNC(static, int, mln_websocket_is_valid_status_code, (mln_u16_t status), (status), {
     if (status >= 1000 && status <= 1003) return 1;
-    if (status == 1004) return 0;
     if (status == 1005 || status == 1006) return 0;
     if (status >= 1007 && status <= 1011) return 1;
     if (status >= 1012 && status <= 1014) return 1;
@@ -651,25 +672,38 @@ MLN_FUNC(static, int, mln_websocket_is_valid_status_code, (mln_u16_t status), (s
 
 MLN_FUNC(static, int, mln_websocket_is_valid_utf8, (mln_u8ptr_t data, mln_size_t len), (data, len), {
     mln_size_t i = 0;
-    mln_u8_t byte;
+    mln_u8_t b0, b1, b2, b3;
+    mln_u32_t cp;
     while (i < len) {
-        byte = data[i];
-        if ((byte & 0x80) == 0) {
+        b0 = data[i];
+        if (b0 < 0x80) {
             i += 1;
-        } else if ((byte & 0xE0) == 0xC0) {
+        } else if ((b0 & 0xE0) == 0xC0) {
             if (i + 1 >= len) return 0;
-            if ((data[i+1] & 0xC0) != 0x80) return 0;
+            b1 = data[i+1];
+            if ((b1 & 0xC0) != 0x80) return 0;
+            cp = ((mln_u32_t)(b0 & 0x1F) << 6) | (b1 & 0x3F);
+            if (cp < 0x80) return 0;           /* overlong */
             i += 2;
-        } else if ((byte & 0xF0) == 0xE0) {
+        } else if ((b0 & 0xF0) == 0xE0) {
             if (i + 2 >= len) return 0;
-            if ((data[i+1] & 0xC0) != 0x80) return 0;
-            if ((data[i+2] & 0xC0) != 0x80) return 0;
+            b1 = data[i+1]; b2 = data[i+2];
+            if ((b1 & 0xC0) != 0x80) return 0;
+            if ((b2 & 0xC0) != 0x80) return 0;
+            cp = ((mln_u32_t)(b0 & 0x0F) << 12) | ((mln_u32_t)(b1 & 0x3F) << 6) | (b2 & 0x3F);
+            if (cp < 0x800) return 0;          /* overlong */
+            if (cp >= 0xD800 && cp <= 0xDFFF) return 0; /* surrogate halves */
             i += 3;
-        } else if ((byte & 0xF8) == 0xF0) {
+        } else if ((b0 & 0xF8) == 0xF0) {
             if (i + 3 >= len) return 0;
-            if ((data[i+1] & 0xC0) != 0x80) return 0;
-            if ((data[i+2] & 0xC0) != 0x80) return 0;
-            if ((data[i+3] & 0xC0) != 0x80) return 0;
+            b1 = data[i+1]; b2 = data[i+2]; b3 = data[i+3];
+            if ((b1 & 0xC0) != 0x80) return 0;
+            if ((b2 & 0xC0) != 0x80) return 0;
+            if ((b3 & 0xC0) != 0x80) return 0;
+            cp = ((mln_u32_t)(b0 & 0x07) << 18) | ((mln_u32_t)(b1 & 0x3F) << 12) |
+                 ((mln_u32_t)(b2 & 0x3F) << 6) | (b3 & 0x3F);
+            if (cp < 0x10000) return 0;        /* overlong */
+            if (cp > 0x10FFFF) return 0;       /* out of range */
             i += 4;
         } else {
             return 0;
@@ -801,34 +835,40 @@ MLN_FUNC(, int, mln_websocket_generate, \
 
     if (mln_websocket_get_maskbit(ws)) {
         mln_u8_t tmpkey[4];
-        mln_u32_t i, j, m = mln_websocket_get_masking_key(ws);
+        mln_u32_t m = mln_websocket_get_masking_key(ws);
         mln_u8ptr_t pc = (mln_u8ptr_t)content;
         *p++ = tmpkey[0] = ((m >> 24) & 0xff);
         *p++ = tmpkey[1] = ((m >> 16) & 0xff);
         *p++ = tmpkey[2] = ((m >> 8) & 0xff);
         *p++ = tmpkey[3] = (m & 0xff);
 
-        i = 0;
+        mln_u32_t mask_offset = 0;
         if (opcode == M_WS_OPCODE_CLOSE) {
-            *p++ = ((mln_websocket_get_status(ws) >> 8) & 0xff) ^ tmpkey[i++%4];
-            *p++ = (mln_websocket_get_status(ws) & 0xff) ^ tmpkey[i++%4];
+            *p++ = ((mln_websocket_get_status(ws) >> 8) & 0xff) ^ tmpkey[0];
+            *p++ = (mln_websocket_get_status(ws) & 0xff) ^ tmpkey[1];
+            mask_offset = 2;
         }
 
         mln_size_t remaining = clen - (opcode == M_WS_OPCODE_CLOSE ? 2 : 0);
+        /* Build key rotated by mask_offset for remaining payload */
+        mln_u8_t rotkey[4];
+        rotkey[0] = tmpkey[mask_offset % 4];
+        rotkey[1] = tmpkey[(mask_offset + 1) % 4];
+        rotkey[2] = tmpkey[(mask_offset + 2) % 4];
+        rotkey[3] = tmpkey[(mask_offset + 3) % 4];
         mln_size_t aligned = remaining & ~3;
         mln_size_t k;
-        mln_u32_t *ptr32 = (mln_u32_t *)p;
-        mln_u32_t *src32 = (mln_u32_t *)pc;
-        mln_u32_t key32;
-        memcpy(&key32, tmpkey, 4);
-
+        mln_u32_t key32_rot, word;
+        memcpy(&key32_rot, rotkey, 4);
         for (k = 0; k < aligned; k += 4) {
-            ptr32[k/4] = src32[k/4] ^ key32;
+            memcpy(&word, pc + k, 4);
+            word ^= key32_rot;
+            memcpy(p + k, &word, 4);
         }
         p += aligned;
-
+        mln_size_t j;
         for (j = aligned; j < remaining; ++j) {
-            *p++ = pc[j] ^ tmpkey[j%4];
+            *p++ = pc[j] ^ rotkey[j % 4];
         }
     } else {
         if (opcode == M_WS_OPCODE_CLOSE) {
@@ -1024,7 +1064,12 @@ againc:
             mln_websocket_set_status(ws, unmasked_status);
         }
         if (content != NULL && len > 0) {
-            mln_websocket_unmask_xor4(content, len, masking_key);
+            mln_u32_t unmask_key = masking_key;
+            if (mln_websocket_get_opcode(ws) == M_WS_OPCODE_CLOSE && close_status != 0) {
+                /* 2 status bytes consumed 2 mask positions; rotate key by 2 to continue */
+                unmask_key = (masking_key << 16) | (masking_key >> 16);
+            }
+            mln_websocket_unmask_xor4(content, len, unmask_key);
         }
     } else {
         if ((b1 & 0x40) || (b1 & 0x20) || (b1 & 0x10)) {

--- a/src/mln_websocket.c
+++ b/src/mln_websocket.c
@@ -850,12 +850,14 @@ MLN_FUNC(, int, mln_websocket_generate, \
         }
 
         mln_size_t remaining = clen - (opcode == M_WS_OPCODE_CLOSE ? 2 : 0);
-        /* Build key rotated by mask_offset for remaining payload */
+        /* Build key rotated by mask_offset (0 or 2) for remaining payload */
         mln_u8_t rotkey[4];
-        rotkey[0] = tmpkey[mask_offset % 4];
-        rotkey[1] = tmpkey[(mask_offset + 1) % 4];
-        rotkey[2] = tmpkey[(mask_offset + 2) % 4];
-        rotkey[3] = tmpkey[(mask_offset + 3) % 4];
+        if (mask_offset == 0) {
+            memcpy(rotkey, tmpkey, 4);
+        } else {
+            rotkey[0] = tmpkey[2]; rotkey[1] = tmpkey[3];
+            rotkey[2] = tmpkey[0]; rotkey[3] = tmpkey[1];
+        }
         mln_size_t aligned = remaining & ~3;
         mln_size_t k;
         mln_u32_t key32_rot, word;

--- a/t/chain.c
+++ b/t/chain.c
@@ -1,43 +1,281 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
+#include <time.h>
 #include "mln_chain.h"
 
-int main(int argc, char *argv[])
+static long elapsed_us(struct timespec *start, struct timespec *end)
 {
-    char *p;
-    char *buf;
-    mln_alloc_t *pool;
-    mln_chain_t *c;
-    mln_buf_t *b;
+    long sec_us = (end->tv_sec - start->tv_sec) * 1000000L;
+    long nsec_us = (end->tv_nsec - start->tv_nsec) / 1000L;
+    return sec_us + nsec_us;
+}
 
-    pool = mln_alloc_init(NULL, 0);
-    if (pool == NULL) {
-        fprintf(stderr, "pool init failed.\n");
-        return -1;
-    }
+static void test_basic(void)
+{
+    printf("Testing basic allocation...\n");
+    mln_alloc_t *pool = mln_alloc_init(NULL, 0);
+    assert(pool != NULL);
 
-    if ((c = mln_chain_new(pool)) == NULL) {
-        fprintf(stderr, "chain_new failed.\n");
-        return -1;
-    }
-    if ((b = mln_buf_new(pool)) == NULL) {
-        fprintf(stderr, "buf_new failed.\n");
-        return -1;
-    }
-    c->buf = b;
-    if ((buf = (char *)mln_alloc_m(pool, 1024)) == NULL) {
-        fprintf(stderr, "buffer allocate failed.\n");
-        return -1;
-    }
-    b->left_pos = b->pos = b->start = (mln_u8ptr_t)buf;
-    b->last = b->end = (mln_u8ptr_t)buf + 1024;
-    b->in_memory = 1;
+    mln_buf_t *b = mln_buf_new(pool);
+    assert(b != NULL);
+    assert(b->left_pos == NULL);
+    assert(b->pos == NULL);
+    assert(b->last == NULL);
+    assert(b->shadow == NULL);
+    assert(b->in_memory == 0);
+    assert(b->in_file == 0);
+    assert(b->temporary == 0);
+    assert(b->flush == 0);
+    assert(b->sync == 0);
+    assert(b->last_buf == 0);
+    assert(b->last_in_chain == 0);
 
-    buf[0] = 'H', buf[1] = 'i';
+    mln_chain_t *c = mln_chain_new(pool);
+    assert(c != NULL);
+    assert(c->buf == NULL);
+    assert(c->next == NULL);
+
+    mln_chain_pool_release(c);
+    mln_buf_pool_release(b);
+    mln_alloc_destroy(pool);
+    printf("  PASS: basic allocation\n");
+}
+
+static void test_chain_new_with_buf(void)
+{
+    printf("Testing chain_new_with_buf...\n");
+    mln_alloc_t *pool = mln_alloc_init(NULL, 0);
+    assert(pool != NULL);
+
+    mln_chain_t *c = mln_chain_new_with_buf(pool);
+    assert(c != NULL);
+    assert(c->buf != NULL);
+    assert(c->next == NULL);
+    assert(c->buf->in_memory == 0);
+    assert(c->buf->in_file == 0);
 
     mln_chain_pool_release(c);
     mln_alloc_destroy(pool);
+    printf("  PASS: chain_new_with_buf\n");
+}
 
+static void test_buf_types(void)
+{
+    printf("Testing buffer types...\n");
+    mln_alloc_t *pool = mln_alloc_init(NULL, 0);
+    assert(pool != NULL);
+
+    /* in_memory buffer */
+    mln_buf_t *b1 = mln_buf_new(pool);
+    assert(b1 != NULL);
+    mln_u8ptr_t mem = (mln_u8ptr_t)mln_alloc_m(pool, 1024);
+    assert(mem != NULL);
+    b1->left_pos = b1->pos = b1->start = mem;
+    b1->last = b1->end = mem + 1024;
+    b1->in_memory = 1;
+    mln_buf_pool_release(b1);
+
+    /* temporary buffer */
+    mln_buf_t *b2 = mln_buf_new(pool);
+    assert(b2 != NULL);
+    b2->temporary = 1;
+    mln_buf_pool_release(b2);
+
+    /* shadow buffer */
+    mln_buf_t *b3 = mln_buf_new(pool);
+    assert(b3 != NULL);
+    mln_buf_t *bs = mln_buf_new(pool);
+    assert(bs != NULL);
+    b3->shadow = bs;
+    mln_buf_pool_release(b3);
+    mln_buf_pool_release(bs);
+
+    /* bare buffer (no flags) */
+    mln_buf_t *b4 = mln_buf_new(pool);
+    assert(b4 != NULL);
+    mln_buf_pool_release(b4);
+
+    mln_alloc_destroy(pool);
+    printf("  PASS: buffer types\n");
+}
+
+static void test_chain_macros(void)
+{
+    printf("Testing chain macros...\n");
+    mln_alloc_t *pool = mln_alloc_init(NULL, 0);
+    assert(pool != NULL);
+
+    mln_chain_t *head = NULL, *tail = NULL;
+
+    for (int i = 0; i < 5; i++) {
+        mln_chain_t *c = mln_chain_new(pool);
+        assert(c != NULL);
+        mln_buf_t *b = mln_buf_new(pool);
+        assert(b != NULL);
+        c->buf = b;
+
+        mln_u8ptr_t mem = (mln_u8ptr_t)mln_alloc_m(pool, 256);
+        assert(mem != NULL);
+        b->left_pos = b->start = mem;
+        b->pos = mem + 10;
+        b->last = b->end = mem + 256;
+        b->in_memory = 1;
+
+        mln_chain_add(&head, &tail, c);
+    }
+
+    assert(head != NULL);
+    assert(tail != NULL);
+
+    int count = 0;
+    mln_chain_t *iter = head;
+    while (iter != NULL) {
+        assert(iter->buf != NULL);
+        assert(mln_buf_size(iter->buf) == 246);
+        assert(mln_buf_left_size(iter->buf) > 0);
+        iter = iter->next;
+        count++;
+    }
+    assert(count == 5);
+
+    /* mln_buf_size / mln_buf_left_size with valid buf */
+    {
+        mln_buf_t *nb = mln_buf_new(pool);
+        assert(nb != NULL);
+        assert(mln_buf_size(nb) == 0);
+        assert(mln_buf_left_size(nb) == 0);
+        mln_buf_pool_release(nb);
+    }
+
+    mln_chain_pool_release_all(head);
+    mln_alloc_destroy(pool);
+    printf("  PASS: chain macros\n");
+}
+
+static void test_release_all(void)
+{
+    printf("Testing release_all...\n");
+    mln_alloc_t *pool = mln_alloc_init(NULL, 0);
+    assert(pool != NULL);
+
+    mln_chain_t *head = NULL, *tail = NULL;
+    for (int i = 0; i < 10; i++) {
+        mln_chain_t *c = mln_chain_new_with_buf(pool);
+        assert(c != NULL);
+        mln_chain_add(&head, &tail, c);
+    }
+
+    mln_chain_pool_release_all(head);
+
+    /* Releasing NULL should be safe */
+    mln_chain_pool_release_all(NULL);
+    mln_chain_pool_release(NULL);
+    mln_buf_pool_release(NULL);
+
+    mln_alloc_destroy(pool);
+    printf("  PASS: release_all\n");
+}
+
+static void test_performance(void)
+{
+    printf("Testing performance (1000000 iterations)...\n");
+
+    mln_alloc_t *pool = mln_alloc_init(NULL, 0);
+    assert(pool != NULL);
+
+    struct timespec start, end;
+    const int N = 1000000;
+
+    /* Benchmark: chain_new + buf_new + release */
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (int i = 0; i < N; i++) {
+        mln_chain_t *c = mln_chain_new(pool);
+        mln_buf_t *b = mln_buf_new(pool);
+        if (c != NULL && b != NULL) {
+            c->buf = b;
+            mln_chain_pool_release(c);
+        }
+    }
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    long us_separate = elapsed_us(&start, &end);
+
+    /* Benchmark: chain_new_with_buf + release */
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (int i = 0; i < N; i++) {
+        mln_chain_t *c = mln_chain_new_with_buf(pool);
+        if (c != NULL) {
+            mln_chain_pool_release(c);
+        }
+    }
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    long us_combined = elapsed_us(&start, &end);
+
+    printf("  Separate alloc: %ld us (%.0f ops/sec)\n",
+           us_separate, (N * 1000000.0) / us_separate);
+    printf("  Combined alloc: %ld us (%.0f ops/sec)\n",
+           us_combined, (N * 1000000.0) / us_combined);
+    if (us_combined > 0)
+        printf("  Combined speedup: %.2fx\n", (double)us_separate / us_combined);
+
+    mln_alloc_destroy(pool);
+    printf("  PASS: performance\n");
+}
+
+static void test_stability(void)
+{
+    printf("Testing stability with heavy usage...\n");
+
+    mln_alloc_t *pool = mln_alloc_init(NULL, 0);
+    assert(pool != NULL);
+
+    for (int round = 0; round < 100; round++) {
+        mln_chain_t *head = NULL, *tail = NULL;
+        int len = (round % 50) + 1;
+
+        for (int i = 0; i < len; i++) {
+            mln_chain_t *c = mln_chain_new_with_buf(pool);
+            assert(c != NULL);
+
+            mln_u8ptr_t mem = (mln_u8ptr_t)mln_alloc_m(pool, 128);
+            if (mem != NULL) {
+                memset(mem, 'A' + (i % 26), 128);
+                c->buf->left_pos = c->buf->pos = c->buf->start = mem;
+                c->buf->last = c->buf->end = mem + 128;
+                c->buf->in_memory = 1;
+            }
+            mln_chain_add(&head, &tail, c);
+        }
+
+        /* Verify chain integrity */
+        int count = 0;
+        mln_chain_t *iter = head;
+        while (iter != NULL) {
+            count++;
+            iter = iter->next;
+        }
+        assert(count == len);
+
+        mln_chain_pool_release_all(head);
+    }
+
+    mln_alloc_destroy(pool);
+    printf("  PASS: stability\n");
+}
+
+int main(void)
+{
+    printf("=== Chain Module Tests ===\n\n");
+
+    test_basic();
+    test_chain_new_with_buf();
+    test_buf_types();
+    test_chain_macros();
+    test_release_all();
+    test_performance();
+    test_stability();
+
+    printf("\n=== All chain tests passed! ===\n");
     return 0;
 }

--- a/t/connection.c
+++ b/t/connection.c
@@ -561,6 +561,187 @@ static void test_stability(void)
     printf("  PASS: stability test\n");
 }
 
+/* Test 11: recv returns M_C_CLOSED when peer closes connection */
+static void test_recv_closed(void)
+{
+    printf("Testing recv with closed connection...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t conn_recv;
+    assert(mln_tcp_conn_init(&conn_recv, fds[1]) == 0);
+
+    /* Close sender side to signal EOF */
+    close(fds[0]);
+
+    /* Recv should return M_C_CLOSED when peer closes */
+    int ret = mln_tcp_conn_recv(&conn_recv, M_C_TYPE_MEMORY);
+    assert(ret == M_C_CLOSED);
+
+    mln_tcp_conn_destroy(&conn_recv);
+    close(fds[1]);
+
+    printf("  PASS: recv closed connection\n");
+}
+
+/* Test 12: recv returns M_C_NOTYET on non-blocking socket with no data */
+static void test_recv_notyet_nonblock(void)
+{
+    printf("Testing recv on non-blocking socket (no data)...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t conn_recv;
+    assert(mln_tcp_conn_init(&conn_recv, fds[1]) == 0);
+
+    /* Set to non-blocking mode */
+    set_nonblock(fds[1]);
+    mln_tcp_conn_set_nonblock(&conn_recv, 1);
+
+    /* Recv with no data available should return M_C_NOTYET (EAGAIN) */
+    int ret = mln_tcp_conn_recv(&conn_recv, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET);
+
+    mln_tcp_conn_destroy(&conn_recv);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: recv non-blocking no data\n");
+}
+
+/* Test 13: recv returns M_C_NOTYET on blocking socket after reading data */
+static void test_recv_notyet_blocking(void)
+{
+    printf("Testing recv on blocking socket...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t conn_send, conn_recv;
+    assert(mln_tcp_conn_init(&conn_send, fds[0]) == 0);
+    assert(mln_tcp_conn_init(&conn_recv, fds[1]) == 0);
+
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn_send);
+
+    /* Send some data */
+    const char *data = "test data";
+    int data_len = strlen(data);
+
+    mln_u8ptr_t buf = (mln_u8ptr_t)mln_alloc_m(pool, data_len + 1);
+    assert(buf != NULL);
+    memcpy(buf, data, data_len);
+
+    mln_chain_t *c = mln_chain_new(pool);
+    mln_buf_t *b = mln_buf_new(pool);
+    assert(c != NULL && b != NULL);
+
+    c->buf = b;
+    b->left_pos = b->pos = b->start = buf;
+    b->last = b->end = buf + data_len;
+    b->in_memory = 1;
+    b->last_buf = 1;
+    b->last_in_chain = 1;
+
+    mln_tcp_conn_append(&conn_send, c, M_C_SEND);
+
+    int ret = mln_tcp_conn_send(&conn_send);
+    assert(ret == M_C_FINISH);
+
+    /* Blocking recv should return M_C_NOTYET after reading data chunk */
+    ret = mln_tcp_conn_recv(&conn_recv, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET);
+
+    /* Verify data was received */
+    mln_chain_t *recv_chain = mln_tcp_conn_head(&conn_recv, M_C_RECV);
+    assert(recv_chain != NULL);
+
+    mln_tcp_conn_destroy(&conn_send);
+    mln_tcp_conn_destroy(&conn_recv);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: recv blocking socket\n");
+}
+
+/* Test 14: recv returns M_C_ERROR on invalid fd */
+static void test_recv_error(void)
+{
+    printf("Testing recv with invalid fd...\n");
+
+    mln_tcp_conn_t conn;
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+
+    /* Recv on invalid fd should return M_C_ERROR */
+    int ret = mln_tcp_conn_recv(&conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_ERROR);
+
+    mln_tcp_conn_destroy(&conn);
+
+    printf("  PASS: recv error handling\n");
+}
+
+/* Test 15: recv with M_C_TYPE_MEMORY after partial send (nonblocking NOTYET) */
+static void test_recv_after_nonblock_send(void)
+{
+    printf("Testing recv after nonblocking send...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]);
+    set_nonblock(fds[1]);
+
+    mln_tcp_conn_t conn_send, conn_recv;
+    assert(mln_tcp_conn_init(&conn_send, fds[0]) == 0);
+    assert(mln_tcp_conn_init(&conn_recv, fds[1]) == 0);
+    mln_tcp_conn_set_nonblock(&conn_send, 1);
+    mln_tcp_conn_set_nonblock(&conn_recv, 1);
+
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn_send);
+
+    /* Send data */
+    const char *data = "nonblock test data";
+    int data_len = strlen(data);
+
+    mln_u8ptr_t buf = (mln_u8ptr_t)mln_alloc_m(pool, data_len + 1);
+    assert(buf != NULL);
+    memcpy(buf, data, data_len);
+
+    mln_chain_t *c = mln_chain_new(pool);
+    mln_buf_t *b = mln_buf_new(pool);
+    assert(c != NULL && b != NULL);
+
+    c->buf = b;
+    b->left_pos = b->pos = b->start = buf;
+    b->last = b->end = buf + data_len;
+    b->in_memory = 1;
+    b->last_buf = 1;
+    b->last_in_chain = 1;
+
+    mln_tcp_conn_append(&conn_send, c, M_C_SEND);
+
+    int ret = mln_tcp_conn_send(&conn_send);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Recv on nonblock - should get data or NOTYET */
+    ret = mln_tcp_conn_recv(&conn_recv, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET);
+
+    /* Verify data was received */
+    mln_chain_t *recv_chain = mln_tcp_conn_head(&conn_recv, M_C_RECV);
+    assert(recv_chain != NULL);
+    assert(recv_chain->buf != NULL);
+    assert(memcmp(recv_chain->buf->pos, data, data_len) == 0);
+
+    mln_tcp_conn_destroy(&conn_send);
+    mln_tcp_conn_destroy(&conn_recv);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: recv after nonblock send\n");
+}
+
 int main(void)
 {
     printf("=== Connection Module Comprehensive Tests ===\n\n");
@@ -575,6 +756,11 @@ int main(void)
     test_multiple_cycles();
     test_performance();
     test_stability();
+    test_recv_closed();
+    test_recv_notyet_nonblock();
+    test_recv_notyet_blocking();
+    test_recv_error();
+    test_recv_after_nonblock_send();
 
     printf("\n=== All connection tests passed! ===\n");
     return 0;

--- a/t/connection.c
+++ b/t/connection.c
@@ -682,7 +682,70 @@ static void test_recv_error(void)
     printf("  PASS: recv error handling\n");
 }
 
-/* Test 15: recv with M_C_TYPE_MEMORY after partial send (nonblocking NOTYET) */
+/* Test 15: send returns M_C_FINISH when all data is successfully written */
+static void test_send_finish(void)
+{
+    printf("Testing send returns M_C_FINISH...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]);
+    set_nonblock(fds[1]);
+
+    mln_tcp_conn_t conn_send, conn_recv;
+    assert(mln_tcp_conn_init(&conn_send, fds[0]) == 0);
+    assert(mln_tcp_conn_init(&conn_recv, fds[1]) == 0);
+    mln_tcp_conn_set_nonblock(&conn_send, 1);
+    mln_tcp_conn_set_nonblock(&conn_recv, 1);
+
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn_send);
+
+    /* Send a small chunk - should complete immediately, returning M_C_FINISH */
+    const char *data = "M_C_FINISH test";
+    int data_len = strlen(data);
+
+    mln_u8ptr_t buf = (mln_u8ptr_t)mln_alloc_m(pool, data_len);
+    assert(buf != NULL);
+    memcpy(buf, data, data_len);
+
+    mln_chain_t *c = mln_chain_new(pool);
+    mln_buf_t *b = mln_buf_new(pool);
+    assert(c != NULL && b != NULL);
+    c->buf = b;
+    b->left_pos = b->pos = b->start = buf;
+    b->last = b->end = buf + data_len;
+    b->in_memory = 1;
+    b->last_buf = 1;
+    b->last_in_chain = 1;
+
+    mln_tcp_conn_append(&conn_send, c, M_C_SEND);
+
+    int ret = mln_tcp_conn_send(&conn_send);
+    assert(ret == M_C_FINISH);
+
+    /* After M_C_FINISH, send queue should be empty */
+    assert(mln_tcp_conn_head(&conn_send, M_C_SEND) == NULL);
+
+    /* Sent data should be in the SENT queue */
+    assert(mln_tcp_conn_head(&conn_send, M_C_SENT) != NULL);
+
+    /* Verify the receiver can read the data */
+    ret = mln_tcp_conn_recv(&conn_recv, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET);
+    mln_chain_t *rc = mln_tcp_conn_head(&conn_recv, M_C_RECV);
+    assert(rc != NULL && rc->buf != NULL);
+    assert((int)(rc->buf->last - rc->buf->pos) == data_len);
+    assert(memcmp(rc->buf->pos, data, data_len) == 0);
+
+    mln_tcp_conn_destroy(&conn_send);
+    mln_tcp_conn_destroy(&conn_recv);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: send returns M_C_FINISH\n");
+}
+
+/* Test 16: recv with M_C_TYPE_MEMORY after partial send (nonblocking NOTYET) */
 static void test_recv_after_nonblock_send(void)
 {
     printf("Testing recv after nonblocking send...\n");
@@ -760,6 +823,7 @@ int main(void)
     test_recv_notyet_nonblock();
     test_recv_notyet_blocking();
     test_recv_error();
+    test_send_finish();
     test_recv_after_nonblock_send();
 
     printf("\n=== All connection tests passed! ===\n");

--- a/t/connection.c
+++ b/t/connection.c
@@ -1,48 +1,581 @@
-#include "mln_connection.h"
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <assert.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include "mln_connection.h"
 
-int main(void)
+/* Helper function to calculate elapsed time in microseconds */
+static long elapsed_us(struct timespec *start, struct timespec *end)
 {
+    long sec_us = (end->tv_sec - start->tv_sec) * 1000000L;
+    long nsec_us = (end->tv_nsec - start->tv_nsec) / 1000L;
+    return sec_us + nsec_us;
+}
+
+/* Helper to set socket to non-blocking mode */
+static void set_nonblock(int fd)
+{
+    int flags = fcntl(fd, F_GETFL, 0);
+    assert(flags >= 0);
+    assert(fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0);
+}
+
+/* Test 1: Basic initialization and destruction */
+static void test_basic(void)
+{
+    printf("Testing basic initialization and destruction...\n");
+
     int fds[2];
-    mln_tcp_conn_t conn1, conn2;
-    mln_chain_t *c;
-    mln_buf_t *b;
-    mln_alloc_t *pool;
-    mln_u8ptr_t buf;
-
     assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
-    assert(mln_tcp_conn_init(&conn1, fds[0]) == 0);
-    assert(mln_tcp_conn_init(&conn2, fds[1]) == 0);
 
-    pool = mln_tcp_conn_pool_get(&conn1);
+    mln_tcp_conn_t conn;
+    assert(mln_tcp_conn_init(&conn, fds[0]) == 0);
 
-    assert((buf = (mln_u8ptr_t)mln_alloc_m(pool, 10)) != NULL);
-    memset(buf, 'a', 9);
-    buf[9] = 0;
-    assert((c = mln_chain_new(pool)) != NULL);
-    assert((b = mln_buf_new(pool)) != NULL);
-    c->buf = b;
-    b->left_pos = b->pos = b->start = buf;
-    b->last = b->end = buf + 10;
-    b->in_memory = 1;
-    b->last_buf = 1;
-    b->last_in_chain = 1;
-    mln_tcp_conn_append(&conn1, c, M_C_SEND);
+    /* Verify initialization */
+    assert(mln_tcp_conn_fd_get(&conn) == fds[0]);
+    assert(mln_tcp_conn_pool_get(&conn) != NULL);
+    assert(mln_tcp_conn_send_empty(&conn));
+    assert(mln_tcp_conn_recv_empty(&conn));
+    assert(mln_tcp_conn_sent_empty(&conn));
 
-    assert(mln_tcp_conn_send(&conn1) == M_C_FINISH);
+    /* Destroy connection */
+    mln_tcp_conn_destroy(&conn);
 
-    assert(mln_tcp_conn_recv(&conn2, M_C_TYPE_MEMORY) != M_C_ERROR);
-
-    assert(memcmp(mln_tcp_conn_head(&conn2, M_C_RECV)->buf->start, buf, 10) == 0);
-
-    mln_tcp_conn_destroy(&conn1);
-    mln_tcp_conn_destroy(&conn2);
     close(fds[0]);
     close(fds[1]);
 
-    return 0;
+    printf("  PASS: basic initialization\n");
 }
 
+/* Test 2: Queue operations (append, pop, head, tail, remove) */
+static void test_queue_ops(void)
+{
+    printf("Testing queue operations...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t conn;
+    assert(mln_tcp_conn_init(&conn, fds[0]) == 0);
+
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn);
+    assert(pool != NULL);
+
+    /* Test append one-by-one to SEND queue */
+    mln_chain_t *c1 = mln_chain_new(pool);
+    mln_chain_t *c2 = mln_chain_new(pool);
+    mln_chain_t *c3 = mln_chain_new(pool);
+    assert(c1 != NULL && c2 != NULL && c3 != NULL);
+
+    mln_tcp_conn_append(&conn, c1, M_C_SEND);
+    mln_tcp_conn_append(&conn, c2, M_C_SEND);
+    mln_tcp_conn_append(&conn, c3, M_C_SEND);
+    assert(mln_tcp_conn_head(&conn, M_C_SEND) == c1);
+    assert(mln_tcp_conn_tail(&conn, M_C_SEND) == c3);
+
+    /* Test append_chain: build a linked list and append it */
+    mln_chain_t *c4 = mln_chain_new(pool);
+    mln_chain_t *c5 = mln_chain_new(pool);
+    assert(c4 != NULL && c5 != NULL);
+    c4->next = c5;
+    mln_tcp_conn_append_chain(&conn, c4, c5, M_C_RECV);
+    assert(mln_tcp_conn_head(&conn, M_C_RECV) == c4);
+    assert(mln_tcp_conn_tail(&conn, M_C_RECV) == c5);
+
+    /* Test pop from SEND queue */
+    mln_chain_t *popped = mln_tcp_conn_pop(&conn, M_C_SEND);
+    assert(popped == c1);
+    assert(mln_tcp_conn_head(&conn, M_C_SEND) == c2);
+    assert(mln_tcp_conn_tail(&conn, M_C_SEND) == c3);
+
+    /* Test pop remaining */
+    popped = mln_tcp_conn_pop(&conn, M_C_SEND);
+    assert(popped == c2);
+    popped = mln_tcp_conn_pop(&conn, M_C_SEND);
+    assert(popped == c3);
+    assert(mln_tcp_conn_send_empty(&conn));
+
+    /* Test remove all from RECV queue */
+    assert(mln_tcp_conn_head(&conn, M_C_RECV) == c4);
+    mln_chain_t *removed = mln_tcp_conn_remove(&conn, M_C_RECV);
+    assert(removed == c4);
+    assert(mln_tcp_conn_recv_empty(&conn));
+
+    mln_tcp_conn_destroy(&conn);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: queue operations\n");
+}
+
+/* Test 3: Send and receive data */
+static void test_send_recv(void)
+{
+    printf("Testing send and receive...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t conn_send, conn_recv;
+    assert(mln_tcp_conn_init(&conn_send, fds[0]) == 0);
+    assert(mln_tcp_conn_init(&conn_recv, fds[1]) == 0);
+
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn_send);
+
+    /* Prepare data to send */
+    const char *data = "Hello, World!";
+    int data_len = strlen(data);
+
+    mln_u8ptr_t buf = (mln_u8ptr_t)mln_alloc_m(pool, data_len + 1);
+    assert(buf != NULL);
+    memcpy(buf, data, data_len);
+
+    mln_chain_t *c = mln_chain_new(pool);
+    mln_buf_t *b = mln_buf_new(pool);
+    assert(c != NULL && b != NULL);
+
+    c->buf = b;
+    b->left_pos = b->pos = b->start = buf;
+    b->last = b->end = buf + data_len;
+    b->in_memory = 1;
+    b->last_buf = 1;
+    b->last_in_chain = 1;
+
+    mln_tcp_conn_append(&conn_send, c, M_C_SEND);
+
+    /* Send data */
+    int ret = mln_tcp_conn_send(&conn_send);
+    assert(ret == M_C_FINISH);
+
+    /* Receive data */
+    ret = mln_tcp_conn_recv(&conn_recv, M_C_TYPE_MEMORY);
+    assert(ret != M_C_ERROR);
+
+    /* Verify received data */
+    mln_chain_t *recv_chain = mln_tcp_conn_head(&conn_recv, M_C_RECV);
+    assert(recv_chain != NULL);
+    assert(recv_chain->buf != NULL);
+    assert(memcmp(recv_chain->buf->start, data, data_len) == 0);
+
+    mln_tcp_conn_destroy(&conn_send);
+    mln_tcp_conn_destroy(&conn_recv);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: send and receive\n");
+}
+
+/* Test 4: Large data send and receive */
+static void test_large_data(void)
+{
+    printf("Testing large data send/recv...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t conn_send, conn_recv;
+    assert(mln_tcp_conn_init(&conn_send, fds[0]) == 0);
+    assert(mln_tcp_conn_init(&conn_recv, fds[1]) == 0);
+
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn_send);
+
+    /* Create large data (>4096 bytes) */
+    const int large_size = 8192;
+    mln_u8ptr_t large_buf = (mln_u8ptr_t)mln_alloc_m(pool, large_size);
+    assert(large_buf != NULL);
+
+    /* Fill with pattern */
+    for (int i = 0; i < large_size; i++) {
+        large_buf[i] = (mln_u8_t)(i % 256);
+    }
+
+    mln_chain_t *c = mln_chain_new(pool);
+    mln_buf_t *b = mln_buf_new(pool);
+    assert(c != NULL && b != NULL);
+
+    c->buf = b;
+    b->left_pos = b->pos = b->start = large_buf;
+    b->last = b->end = large_buf + large_size;
+    b->in_memory = 1;
+    b->last_buf = 1;
+    b->last_in_chain = 1;
+
+    mln_tcp_conn_append(&conn_send, c, M_C_SEND);
+
+    /* Send large data */
+    int ret = mln_tcp_conn_send(&conn_send);
+    assert(ret == M_C_FINISH);
+
+    /* Receive large data - may take multiple reads */
+    int total_recv = 0;
+    while (total_recv < large_size) {
+        ret = mln_tcp_conn_recv(&conn_recv, M_C_TYPE_MEMORY);
+        assert(ret != M_C_ERROR);
+
+        mln_chain_t *iter = mln_tcp_conn_head(&conn_recv, M_C_RECV);
+        total_recv = 0;
+        while (iter != NULL) {
+            if (iter->buf != NULL)
+                total_recv += (int)(iter->buf->last - iter->buf->pos);
+            iter = iter->next;
+        }
+    }
+
+    /* Verify data integrity across all received chunks */
+    mln_chain_t *recv_chain = mln_tcp_conn_head(&conn_recv, M_C_RECV);
+    int offset = 0;
+    while (recv_chain != NULL && offset < large_size) {
+        if (recv_chain->buf != NULL) {
+            int chunk = (int)(recv_chain->buf->last - recv_chain->buf->pos);
+            assert(memcmp(recv_chain->buf->pos, large_buf + offset, chunk) == 0);
+            offset += chunk;
+        }
+        recv_chain = recv_chain->next;
+    }
+    assert(offset == large_size);
+
+    mln_tcp_conn_destroy(&conn_send);
+    mln_tcp_conn_destroy(&conn_recv);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: large data\n");
+}
+
+/* Test 5: mln_tcp_conn_move_sent */
+static void test_move_sent(void)
+{
+    printf("Testing move_sent...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t conn;
+    assert(mln_tcp_conn_init(&conn, fds[0]) == 0);
+
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn);
+
+    /* Add chains to send queue */
+    mln_chain_t *c1 = mln_chain_new(pool);
+    mln_chain_t *c2 = mln_chain_new(pool);
+    assert(c1 != NULL && c2 != NULL);
+
+    mln_tcp_conn_append(&conn, c1, M_C_SEND);
+    mln_tcp_conn_append(&conn, c2, M_C_SEND);
+
+    assert(!mln_tcp_conn_send_empty(&conn));
+    assert(mln_tcp_conn_sent_empty(&conn));
+
+    /* Move from send to sent */
+    mln_tcp_conn_move_sent(&conn);
+
+    assert(mln_tcp_conn_send_empty(&conn));
+    assert(!mln_tcp_conn_sent_empty(&conn));
+    assert(mln_tcp_conn_head(&conn, M_C_SENT) == c1);
+    assert(mln_tcp_conn_tail(&conn, M_C_SENT) == c2);
+
+    mln_tcp_conn_destroy(&conn);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: move_sent\n");
+}
+
+/* Test 6: mln_tcp_conn_send_chain */
+static void test_send_chain(void)
+{
+    printf("Testing send_chain...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t conn_send, conn_recv;
+    assert(mln_tcp_conn_init(&conn_send, fds[0]) == 0);
+    assert(mln_tcp_conn_init(&conn_recv, fds[1]) == 0);
+
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn_send);
+
+    /* Create a chain directly */
+    const char *msg = "Send chain test";
+    mln_u8ptr_t buf = (mln_u8ptr_t)mln_alloc_m(pool, strlen(msg) + 1);
+    assert(buf != NULL);
+    memcpy(buf, msg, strlen(msg));
+
+    mln_chain_t *c = mln_chain_new(pool);
+    mln_buf_t *b = mln_buf_new(pool);
+    assert(c != NULL && b != NULL);
+
+    c->buf = b;
+    b->left_pos = b->pos = b->start = buf;
+    b->last = b->end = buf + strlen(msg);
+    b->in_memory = 1;
+    b->last_buf = 1;
+    b->last_in_chain = 1;
+
+    /* Use mln_tcp_conn_send_chain */
+    int ret = mln_tcp_conn_send_chain(&conn_send, c);
+    assert(ret == M_C_FINISH);
+
+    /* Receive and verify */
+    ret = mln_tcp_conn_recv(&conn_recv, M_C_TYPE_MEMORY);
+    assert(ret != M_C_ERROR);
+
+    mln_chain_t *recv_chain = mln_tcp_conn_head(&conn_recv, M_C_RECV);
+    assert(recv_chain != NULL);
+    assert(memcmp(recv_chain->buf->start, msg, strlen(msg)) == 0);
+
+    mln_tcp_conn_destroy(&conn_send);
+    mln_tcp_conn_destroy(&conn_recv);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: send_chain\n");
+}
+
+/* Test 7: fd_get, fd_set, pool_get macros */
+static void test_macros(void)
+{
+    printf("Testing fd/pool macros...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t conn;
+    assert(mln_tcp_conn_init(&conn, fds[0]) == 0);
+
+    /* Test fd_get macro */
+    int fd = mln_tcp_conn_fd_get(&conn);
+    assert(fd == fds[0]);
+
+    /* Test fd_set macro */
+    mln_tcp_conn_fd_set(&conn, fds[1]);
+    assert(mln_tcp_conn_fd_get(&conn) == fds[1]);
+
+    /* Test pool_get macro */
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn);
+    assert(pool != NULL);
+
+    /* Test set_nonblock macro */
+    mln_tcp_conn_set_nonblock(&conn, 1);
+    assert(conn.nonblock == 1);
+
+    mln_tcp_conn_set_nonblock(&conn, 0);
+    assert(conn.nonblock == 0);
+
+    mln_tcp_conn_destroy(&conn);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: fd/pool macros\n");
+}
+
+/* Test 8: Multiple send/recv cycles */
+static void test_multiple_cycles(void)
+{
+    printf("Testing multiple send/recv cycles...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t conn_send, conn_recv;
+    assert(mln_tcp_conn_init(&conn_send, fds[0]) == 0);
+    assert(mln_tcp_conn_init(&conn_recv, fds[1]) == 0);
+
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn_send);
+
+    /* Multiple send/recv pairs */
+    const char *messages[] = {"msg1", "msg2", "msg3"};
+    int num_msgs = sizeof(messages) / sizeof(messages[0]);
+
+    for (int i = 0; i < num_msgs; i++) {
+        const char *msg = messages[i];
+        int msg_len = strlen(msg);
+
+        /* Prepare send buffer */
+        mln_u8ptr_t buf = (mln_u8ptr_t)mln_alloc_m(pool, msg_len + 1);
+        assert(buf != NULL);
+        memcpy(buf, msg, msg_len);
+
+        mln_chain_t *c = mln_chain_new(pool);
+        mln_buf_t *b = mln_buf_new(pool);
+        assert(c != NULL && b != NULL);
+
+        c->buf = b;
+        b->left_pos = b->pos = b->start = buf;
+        b->last = b->end = buf + msg_len;
+        b->in_memory = 1;
+        b->last_buf = 1;
+        b->last_in_chain = 1;
+
+        mln_tcp_conn_append(&conn_send, c, M_C_SEND);
+
+        /* Send */
+        int ret = mln_tcp_conn_send(&conn_send);
+        assert(ret == M_C_FINISH);
+
+        /* Receive */
+        ret = mln_tcp_conn_recv(&conn_recv, M_C_TYPE_MEMORY);
+        assert(ret != M_C_ERROR);
+
+        /* Verify */
+        mln_chain_t *recv_chain = mln_tcp_conn_head(&conn_recv, M_C_RECV);
+        assert(recv_chain != NULL);
+        assert(memcmp(recv_chain->buf->start, msg, msg_len) == 0);
+
+        /* Clean up recv queue for next iteration */
+        mln_chain_pool_release_all(mln_tcp_conn_remove(&conn_recv, M_C_RECV));
+    }
+
+    mln_tcp_conn_destroy(&conn_send);
+    mln_tcp_conn_destroy(&conn_recv);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: multiple cycles\n");
+}
+
+/* Test 9: Performance benchmark (send/recv throughput) */
+static void test_performance(void)
+{
+    printf("Testing performance (100000 iterations)...\n");
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t conn_send, conn_recv;
+    assert(mln_tcp_conn_init(&conn_send, fds[0]) == 0);
+    assert(mln_tcp_conn_init(&conn_recv, fds[1]) == 0);
+
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn_send);
+
+    const int N = 100000;
+    const char *test_msg = "x";
+    int msg_len = strlen(test_msg);
+
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    for (int i = 0; i < N; i++) {
+        /* Prepare small message */
+        mln_u8ptr_t buf = (mln_u8ptr_t)mln_alloc_m(pool, msg_len + 1);
+        if (buf == NULL) break;
+        memcpy(buf, test_msg, msg_len);
+
+        mln_chain_t *c = mln_chain_new(pool);
+        mln_buf_t *b = mln_buf_new(pool);
+        if (c == NULL || b == NULL) break;
+
+        c->buf = b;
+        b->left_pos = b->pos = b->start = buf;
+        b->last = b->end = buf + msg_len;
+        b->in_memory = 1;
+        b->last_buf = 1;
+        b->last_in_chain = 1;
+
+        mln_tcp_conn_append(&conn_send, c, M_C_SEND);
+
+        /* Send */
+        int ret = mln_tcp_conn_send(&conn_send);
+        if (ret != M_C_FINISH) break;
+
+        /* Receive */
+        ret = mln_tcp_conn_recv(&conn_recv, M_C_TYPE_MEMORY);
+        if (ret == M_C_ERROR) break;
+
+        /* Clean up */
+        mln_chain_pool_release_all(mln_tcp_conn_remove(&conn_recv, M_C_RECV));
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    long elapsed = elapsed_us(&start, &end);
+
+    double throughput = (N * 1000000.0) / elapsed;
+    printf("  Throughput: %.2f messages/sec\n", throughput);
+    printf("  Total time: %ld us\n", elapsed);
+
+    mln_tcp_conn_destroy(&conn_send);
+    mln_tcp_conn_destroy(&conn_recv);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("  PASS: performance benchmark\n");
+}
+
+/* Test 10: Stability test with rapid connections and operations */
+static void test_stability(void)
+{
+    printf("Testing stability with rapid operations...\n");
+
+    const int NUM_CYCLES = 100;
+    const int CHAIN_OPS_PER_CYCLE = 50;
+
+    for (int cycle = 0; cycle < NUM_CYCLES; cycle++) {
+        int fds[2];
+        if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) != 0) continue;
+
+        mln_tcp_conn_t conn;
+        if (mln_tcp_conn_init(&conn, fds[0]) != 0) {
+            close(fds[0]);
+            close(fds[1]);
+            continue;
+        }
+
+        mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn);
+
+        /* Perform many chain operations */
+        for (int op = 0; op < CHAIN_OPS_PER_CYCLE; op++) {
+            mln_chain_t *c = mln_chain_new(pool);
+            mln_buf_t *b = mln_buf_new(pool);
+
+            if (c != NULL && b != NULL) {
+                c->buf = b;
+
+                /* Random operations */
+                int action = op % 3;
+                if (action == 0) {
+                    mln_tcp_conn_append(&conn, c, M_C_SEND);
+                } else if (action == 1) {
+                    mln_tcp_conn_append(&conn, c, M_C_RECV);
+                } else {
+                    mln_tcp_conn_append(&conn, c, M_C_SENT);
+                }
+            }
+        }
+
+        /* Clean up all queues */
+        mln_chain_pool_release_all(mln_tcp_conn_remove(&conn, M_C_SEND));
+        mln_chain_pool_release_all(mln_tcp_conn_remove(&conn, M_C_RECV));
+        mln_chain_pool_release_all(mln_tcp_conn_remove(&conn, M_C_SENT));
+
+        mln_tcp_conn_destroy(&conn);
+        close(fds[0]);
+        close(fds[1]);
+    }
+
+    printf("  PASS: stability test\n");
+}
+
+int main(void)
+{
+    printf("=== Connection Module Comprehensive Tests ===\n\n");
+
+    test_basic();
+    test_queue_ops();
+    test_send_recv();
+    test_large_data();
+    test_move_sent();
+    test_send_chain();
+    test_macros();
+    test_multiple_cycles();
+    test_performance();
+    test_stability();
+
+    printf("\n=== All connection tests passed! ===\n");
+    return 0;
+}

--- a/t/http.c
+++ b/t/http.c
@@ -16,6 +16,25 @@ static void set_nonblock(int fd)
     assert(fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0);
 }
 
+/* Body handler for E2E tests: captures remaining body chain for verification */
+static char e2e_body_buf[4096];
+static int e2e_body_len = 0;
+
+static int e2e_body_handler(mln_http_t *http, mln_chain_t **body_head, mln_chain_t **body_tail)
+{
+    mln_chain_t *c;
+    e2e_body_len = 0;
+    for (c = *body_head; c != NULL; c = c->next) {
+        if (c->buf == NULL) continue;
+        int sz = (int)(c->buf->last - c->buf->left_pos);
+        if (sz > 0 && e2e_body_len + sz < (int)sizeof(e2e_body_buf)) {
+            memcpy(e2e_body_buf + e2e_body_len, c->buf->left_pos, sz);
+            e2e_body_len += sz;
+        }
+    }
+    return M_HTTP_RET_DONE;
+}
+
 static long elapsed_us(struct timespec *start, struct timespec *end)
 {
     long sec_diff = (long)(end->tv_sec - start->tv_sec);
@@ -759,7 +778,11 @@ static void test_e2e_post_with_body(void)
 
     assert(mln_tcp_conn_init(&server_conn, fds[1]) == 0);
     mln_tcp_conn_set_nonblock(&server_conn, 1);
-    assert((server_http = mln_http_init(&server_conn, NULL, NULL)) != NULL);
+    assert((server_http = mln_http_init(&server_conn, NULL, e2e_body_handler)) != NULL);
+
+    /* Reset body capture buffer */
+    e2e_body_len = 0;
+    memset(e2e_body_buf, 0, sizeof(e2e_body_buf));
 
     /* CLIENT: Generate HTTP POST request headers */
     mln_http_type_set(client_http, M_HTTP_REQUEST);
@@ -790,12 +813,14 @@ static void test_e2e_post_with_body(void)
     body_buf->start = body_buf->pos = body_buf->left_pos = (mln_u8ptr_t)(void *)body_str;
     body_buf->last = body_buf->end = (mln_u8ptr_t)(void *)body_str + strlen(body_str);
     body_buf->temporary = 1;
+    body_buf->in_memory = 1;
     body_buf->last_buf = 1;
     body_buf->last_in_chain = 1;
 
-    /* Walk chain to find real tail, then append body */
+    /* Walk chain to find real tail, clear its last_in_chain, then append body */
     mln_chain_t *real_tail = head;
     while (real_tail->next != NULL) real_tail = real_tail->next;
+    if (real_tail->buf != NULL) real_tail->buf->last_in_chain = 0;
     real_tail->next = body_chain;
     real_tail = body_chain;
 
@@ -811,6 +836,11 @@ static void test_e2e_post_with_body(void)
     ret = mln_http_parse(server_http, &c);
     assert(ret == M_HTTP_RET_DONE);
     assert(mln_http_method_get(server_http) == M_HTTP_POST);
+
+    /* Verify parsed body content matches what was sent */
+    assert(e2e_body_len == (int)strlen(body_str));
+    assert(memcmp(e2e_body_buf, body_str, strlen(body_str)) == 0);
+
     if (c != NULL) mln_chain_pool_release_all(c);
 
     /* SERVER: Generate HTTP 201 Created response */

--- a/t/http.c
+++ b/t/http.c
@@ -1,20 +1,231 @@
 #include <stdio.h>
-#include "mln_http.h"
+#include <stdlib.h>
+#include <string.h>
 #include <assert.h>
+#include <time.h>
+#include <unistd.h>
+#include "mln_http.h"
 
-int main(void)
+static long elapsed_us(struct timespec *start, struct timespec *end)
+{
+    long sec_diff = (long)(end->tv_sec - start->tv_sec);
+    long nsec_diff = (long)(end->tv_nsec - start->tv_nsec);
+    return sec_diff * 1000000 + nsec_diff / 1000;
+}
+
+static mln_chain_t *create_chain_from_string(mln_alloc_t *pool, const char *str)
+{
+    mln_chain_t *c;
+    mln_buf_t *b;
+
+    assert((c = mln_chain_new(pool)) != NULL);
+    assert((b = mln_buf_new(pool)) != NULL);
+    c->buf = b;
+    b->start = b->pos = b->left_pos = (mln_u8ptr_t)(void *)str;
+    b->last = b->end = (mln_u8ptr_t)(void *)str + strlen(str);
+    b->temporary = 1;
+    return c;
+}
+
+static void test_request_parse_get(void)
 {
     mln_http_t *http;
     mln_tcp_conn_t conn;
     mln_alloc_t *pool;
-    mln_chain_t *c, *head = NULL, *tail = NULL;
+    mln_chain_t *c;
     mln_buf_t *b;
     char req[] = "GET / HTTP/1.1\r\nHost: 127.0.0.1:8080\r\nUser-Agent: curl/7.81.0\r\n\r\n";
-    mln_string_t key = mln_string("Server");
-    mln_string_t val = mln_string("Melon");
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
-    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL); //no body
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((c = mln_chain_new(pool)) != NULL);
+    assert((b = mln_buf_new(pool)) != NULL);
+    c->buf = b;
+    b->start = b->pos = b->left_pos = (mln_u8ptr_t)req;
+    b->last = b->end = (mln_u8ptr_t)req + sizeof(req) - 1;
+    b->temporary = 1;
+
+    assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+    assert(mln_http_type_get(http) == M_HTTP_REQUEST);
+    assert(mln_http_method_get(http) == M_HTTP_GET);
+    assert(mln_http_version_get(http) == M_HTTP_VERSION_1_1);
+    assert(mln_http_uri_get(http) != NULL);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_request_parse_get\n");
+}
+
+static void test_request_parse_post(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c;
+    mln_buf_t *b;
+    char req[] = "POST /api/data HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\n\r\nhello";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((c = mln_chain_new(pool)) != NULL);
+    assert((b = mln_buf_new(pool)) != NULL);
+    c->buf = b;
+    b->start = b->pos = b->left_pos = (mln_u8ptr_t)req;
+    b->last = b->end = (mln_u8ptr_t)req + sizeof(req) - 1;
+    b->temporary = 1;
+
+    assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+    assert(mln_http_method_get(http) == M_HTTP_POST);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_request_parse_post\n");
+}
+
+static void test_all_http_methods(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c;
+    mln_buf_t *b;
+    char req[256];
+    const char *methods[] = {"GET", "POST", "HEAD", "PUT", "DELETE", "TRACE", "CONNECT", "OPTIONS"};
+    mln_u32_t method_vals[] = {M_HTTP_GET, M_HTTP_POST, M_HTTP_HEAD, M_HTTP_PUT, M_HTTP_DELETE, M_HTTP_TRACE, M_HTTP_CONNECT, M_HTTP_OPTIONS};
+    int i;
+
+    for (i = 0; i < 8; i++) {
+        assert(mln_tcp_conn_init(&conn, -1) == 0);
+        assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+        pool = mln_tcp_conn_pool_get(&conn);
+
+        snprintf(req, sizeof(req), "%s / HTTP/1.1\r\nHost: test.com\r\n\r\n", methods[i]);
+
+        assert((c = mln_chain_new(pool)) != NULL);
+        assert((b = mln_buf_new(pool)) != NULL);
+        c->buf = b;
+        b->start = b->pos = b->left_pos = (mln_u8ptr_t)req;
+        b->last = b->end = (mln_u8ptr_t)req + strlen(req);
+        b->temporary = 1;
+
+        assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+        assert(mln_http_method_get(http) == method_vals[i]);
+
+        if (c != NULL) mln_chain_pool_release(c);
+        mln_http_destroy(http);
+        mln_tcp_conn_destroy(&conn);
+    }
+
+    printf("[PASS] test_all_http_methods\n");
+}
+
+static void test_http_versions(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c;
+    mln_buf_t *b;
+    char req[256];
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    snprintf(req, sizeof(req), "GET / HTTP/1.0\r\nHost: test.com\r\n\r\n");
+
+    assert((c = mln_chain_new(pool)) != NULL);
+    assert((b = mln_buf_new(pool)) != NULL);
+    c->buf = b;
+    b->start = b->pos = b->left_pos = (mln_u8ptr_t)req;
+    b->last = b->end = (mln_u8ptr_t)req + strlen(req);
+    b->temporary = 1;
+
+    assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+    assert(mln_http_version_get(http) == M_HTTP_VERSION_1_0);
+
+    if (c != NULL) mln_chain_pool_release(c);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    snprintf(req, sizeof(req), "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n");
+
+    assert((c = mln_chain_new(pool)) != NULL);
+    assert((b = mln_buf_new(pool)) != NULL);
+    c->buf = b;
+    b->start = b->pos = b->left_pos = (mln_u8ptr_t)req;
+    b->last = b->end = (mln_u8ptr_t)req + strlen(req);
+    b->temporary = 1;
+
+    assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+    assert(mln_http_version_get(http) == M_HTTP_VERSION_1_1);
+
+    if (c != NULL) mln_chain_pool_release(c);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_http_versions\n");
+}
+
+static void test_request_with_query_string(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c;
+    mln_buf_t *b;
+    char req[] = "GET /search?q=test&page=1 HTTP/1.1\r\nHost: test.com\r\n\r\n";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((c = mln_chain_new(pool)) != NULL);
+    assert((b = mln_buf_new(pool)) != NULL);
+    c->buf = b;
+    b->start = b->pos = b->left_pos = (mln_u8ptr_t)req;
+    b->last = b->end = (mln_u8ptr_t)req + sizeof(req) - 1;
+    b->temporary = 1;
+
+    assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+    assert(mln_http_args_get(http) != NULL);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_request_with_query_string\n");
+}
+
+static void test_multiple_headers(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c;
+    mln_buf_t *b;
+    char req[] = "GET / HTTP/1.1\r\nHost: test.com\r\nUser-Agent: test\r\nContent-Type: text/html\r\nAccept: */*\r\n\r\n";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
 
     pool = mln_tcp_conn_pool_get(&conn);
 
@@ -27,17 +238,181 @@ int main(void)
 
     assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
 
-    mln_http_type_set(http, M_HTTP_RESPONSE);
+    if (c != NULL) mln_chain_pool_release(c);
 
-    assert(mln_http_field_set(http, &key, &val) == 0);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_multiple_headers\n");
+}
+
+static void test_response_parse(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c;
+    mln_buf_t *b;
+    char resp[] = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    /* Do not pre-set type; parser auto-detects from HTTP/x.x prefix */
+
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((c = mln_chain_new(pool)) != NULL);
+    assert((b = mln_buf_new(pool)) != NULL);
+    c->buf = b;
+    b->start = b->pos = b->left_pos = (mln_u8ptr_t)resp;
+    b->last = b->end = (mln_u8ptr_t)resp + sizeof(resp) - 1;
+    b->temporary = 1;
+
+    assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+    assert(mln_http_status_get(http) == M_HTTP_OK);
 
     if (c != NULL) mln_chain_pool_release(c);
 
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_response_parse\n");
+}
+
+static void test_response_status_codes(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c;
+    mln_buf_t *b;
+    char resp[256];
+    struct {
+        mln_u32_t code;
+        const char *msg;
+    } tests[] = {
+        {M_HTTP_OK, "200 OK"},
+        {M_HTTP_CREATED, "201 Created"},
+        {M_HTTP_BAD_REQUEST, "400 Bad Request"},
+        {M_HTTP_UNAUTHORIZED, "401 Unauthorized"},
+        {M_HTTP_NOT_FOUND, "404 Not Found"},
+        {M_HTTP_INTERNAL_SERVER_ERROR, "500 Internal Server Error"},
+        {M_HTTP_SERVICE_UNAVAILABLE, "503 Service Unavailable"},
+    };
+    int i;
+
+    for (i = 0; i < 7; i++) {
+        assert(mln_tcp_conn_init(&conn, -1) == 0);
+        assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+        /* Do not pre-set type; parser auto-detects */
+        pool = mln_tcp_conn_pool_get(&conn);
+
+        snprintf(resp, sizeof(resp), "HTTP/1.1 %s\r\n\r\n", tests[i].msg);
+
+        assert((c = mln_chain_new(pool)) != NULL);
+        assert((b = mln_buf_new(pool)) != NULL);
+        c->buf = b;
+        b->start = b->pos = b->left_pos = (mln_u8ptr_t)resp;
+        b->last = b->end = (mln_u8ptr_t)resp + strlen(resp);
+        b->temporary = 1;
+
+        assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+        assert(mln_http_status_get(http) == tests[i].code);
+
+        if (c != NULL) mln_chain_pool_release(c);
+        mln_http_destroy(http);
+        mln_tcp_conn_destroy(&conn);
+    }
+
+    printf("[PASS] test_response_status_codes\n");
+}
+
+static void test_field_operations(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_string_t key, val, val2;
+    mln_string_t *result;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    mln_string_set(&key, "Server");
+    mln_string_set(&val, "Melon");
+    mln_string_set(&val2, "Melon/1.0");
+
+    assert(mln_http_field_set(http, &key, &val) == 0);
+    result = mln_http_field_get(http, &key);
+    assert(result != NULL);
+    assert(result->len == val.len);
+
+    assert(mln_http_field_set(http, &key, &val2) == 0);
+    result = mln_http_field_get(http, &key);
+    assert(result != NULL);
+    assert(result->len == val2.len);
+
+    mln_http_field_remove(http, &key);
+    result = mln_http_field_get(http, &key);
+    assert(result == NULL);
+
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_field_operations\n");
+}
+
+static void test_case_insensitive_headers(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_string_t key_lower, key_upper;
+    mln_string_t val;
+    mln_string_t *result;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    mln_string_set(&key_lower, "content-type");
+    mln_string_set(&key_upper, "Content-Type");
+    mln_string_set(&val, "text/html");
+
+    assert(mln_http_field_set(http, &key_lower, &val) == 0);
+    result = mln_http_field_get(http, &key_upper);
+    assert(result != NULL);
+
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_case_insensitive_headers\n");
+}
+
+static void test_generate_request(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c, *head = NULL, *tail = NULL;
+    mln_string_t key, val;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    mln_http_type_set(http, M_HTTP_REQUEST);
+    mln_http_method_set(http, M_HTTP_GET);
+    mln_http_version_set(http, M_HTTP_VERSION_1_1);
+
+    mln_string_set(&key, "Host");
+    mln_string_set(&val, "example.com");
+    assert(mln_http_field_set(http, &key, &val) == 0);
+
     assert(mln_http_generate(http, &head, &tail) == M_HTTP_RET_DONE);
+    assert(head != NULL);
 
     for (c = head; c != NULL; c = c->next) {
         if (mln_buf_size(c->buf)) {
-            write(STDOUT_FILENO, c->buf->start, mln_buf_size(c->buf));
+            assert(c->buf->start != NULL);
         }
     }
 
@@ -45,6 +420,261 @@ int main(void)
     mln_http_destroy(http);
     mln_tcp_conn_destroy(&conn);
 
-    return 0;
+    printf("[PASS] test_generate_request\n");
 }
 
+static void test_generate_response(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c, *head = NULL, *tail = NULL;
+    mln_string_t key, val;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    mln_http_type_set(http, M_HTTP_RESPONSE);
+    mln_http_status_set(http, M_HTTP_OK);
+    mln_http_version_set(http, M_HTTP_VERSION_1_1);
+
+    mln_string_set(&key, "Content-Type");
+    mln_string_set(&val, "text/html");
+    assert(mln_http_field_set(http, &key, &val) == 0);
+
+    assert(mln_http_generate(http, &head, &tail) == M_HTTP_RET_DONE);
+    assert(head != NULL);
+
+    for (c = head; c != NULL; c = c->next) {
+        if (mln_buf_size(c->buf)) {
+            assert(c->buf->start != NULL);
+        }
+    }
+
+    mln_chain_pool_release_all(head);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_generate_response\n");
+}
+
+static void test_reset(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c;
+    mln_buf_t *b;
+    mln_string_t key, val;
+    char req[] = "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((c = mln_chain_new(pool)) != NULL);
+    assert((b = mln_buf_new(pool)) != NULL);
+    c->buf = b;
+    b->start = b->pos = b->left_pos = (mln_u8ptr_t)req;
+    b->last = b->end = (mln_u8ptr_t)req + sizeof(req) - 1;
+    b->temporary = 1;
+
+    assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+
+    mln_string_set(&key, "Server");
+    mln_string_set(&val, "Test");
+    assert(mln_http_field_set(http, &key, &val) == 0);
+
+    mln_http_reset(http);
+
+    assert(mln_http_method_get(http) == M_HTTP_UNKNOWN);
+    assert(mln_http_field_get(http, &key) == NULL);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_reset\n");
+}
+
+static void test_performance_parse_generate(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c, *head, *tail;
+    mln_buf_t *b;
+    char req[] = "GET /test HTTP/1.1\r\nHost: test.com\r\nUser-Agent: test\r\n\r\n";
+    mln_string_t key, val;
+    struct timespec start, end;
+    long elapsed;
+    int i;
+    int iterations = 100000;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    mln_string_set(&key, "Server");
+    mln_string_set(&val, "Melon");
+
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    for (i = 0; i < iterations; i++) {
+        assert((c = mln_chain_new(pool)) != NULL);
+        assert((b = mln_buf_new(pool)) != NULL);
+        c->buf = b;
+        b->start = b->pos = b->left_pos = (mln_u8ptr_t)req;
+        b->last = b->end = (mln_u8ptr_t)req + sizeof(req) - 1;
+        b->temporary = 1;
+
+        assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+
+        mln_http_type_set(http, M_HTTP_RESPONSE);
+        mln_http_status_set(http, M_HTTP_OK);
+        assert(mln_http_field_set(http, &key, &val) == 0);
+
+        head = NULL;
+        tail = NULL;
+        assert(mln_http_generate(http, &head, &tail) == M_HTTP_RET_DONE);
+        if (head != NULL) mln_chain_pool_release_all(head);
+
+        mln_http_reset(http);
+
+        if (c != NULL) mln_chain_pool_release(c);
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    elapsed = elapsed_us(&start, &end);
+
+    printf("[PERF] parse+generate: %d iterations in %ld us (%.2f ops/sec)\n",
+           iterations, elapsed, (iterations * 1000000.0) / elapsed);
+
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+}
+
+static void test_stability_parse_multiple(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c;
+    mln_buf_t *b;
+    char req[256];
+    int i;
+    int count = 10000;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    for (i = 0; i < count; i++) {
+        snprintf(req, sizeof(req), "GET /path%d HTTP/1.1\r\nHost: test.com\r\n\r\n", i);
+
+        assert((c = mln_chain_new(pool)) != NULL);
+        assert((b = mln_buf_new(pool)) != NULL);
+        c->buf = b;
+        b->start = b->pos = b->left_pos = (mln_u8ptr_t)req;
+        b->last = b->end = (mln_u8ptr_t)req + strlen(req);
+        b->temporary = 1;
+
+        assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+        mln_http_reset(http);
+
+        if (c != NULL) mln_chain_pool_release(c);
+    }
+
+    printf("[PASS] test_stability_parse_multiple (%d requests)\n", count);
+
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+}
+
+static void test_stability_generate_multiple(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *head, *tail;
+    mln_string_t key, val;
+    char val_str[256];
+    int i;
+    int count = 10000;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    mln_http_type_set(http, M_HTTP_RESPONSE);
+    mln_http_version_set(http, M_HTTP_VERSION_1_1);
+    mln_string_set(&key, "Server");
+
+    for (i = 0; i < count; i++) {
+        mln_http_type_set(http, M_HTTP_RESPONSE);
+        mln_http_version_set(http, M_HTTP_VERSION_1_1);
+        mln_http_status_set(http, (i % 5 == 0) ? M_HTTP_OK : M_HTTP_NOT_FOUND);
+
+        snprintf(val_str, sizeof(val_str), "Melon-%d", i);
+        val.data = (mln_u8ptr_t)val_str;
+        val.len = strlen(val_str);
+        val.data_ref = 1;
+        val.pool = 0;
+        val.ref = 1;
+
+        assert(mln_http_field_set(http, &key, &val) == 0);
+        head = NULL;
+        tail = NULL;
+        assert(mln_http_generate(http, &head, &tail) == M_HTTP_RET_DONE);
+
+        if (head != NULL) mln_chain_pool_release_all(head);
+        mln_http_reset(http);
+    }
+
+    printf("[PASS] test_stability_generate_multiple (%d responses)\n", count);
+
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+}
+
+int main(void)
+{
+    printf("===== HTTP Module Tests =====\n\n");
+
+    printf("=== Request Parsing ===\n");
+    test_request_parse_get();
+    test_request_parse_post();
+    test_all_http_methods();
+    test_http_versions();
+    test_request_with_query_string();
+    test_multiple_headers();
+
+    printf("\n=== Response Parsing ===\n");
+    test_response_parse();
+    test_response_status_codes();
+
+    printf("\n=== Header Field Operations ===\n");
+    test_field_operations();
+    test_case_insensitive_headers();
+
+    printf("\n=== HTTP Generation ===\n");
+    test_generate_request();
+    test_generate_response();
+
+    printf("\n=== Reset and Reuse ===\n");
+    test_reset();
+
+    printf("\n=== Performance ===\n");
+    test_performance_parse_generate();
+
+    printf("\n=== Stability ===\n");
+    test_stability_parse_multiple();
+    test_stability_generate_multiple();
+
+    printf("\n===== All tests passed! =====\n");
+    return 0;
+}

--- a/t/http.c
+++ b/t/http.c
@@ -178,6 +178,7 @@ static void test_http_versions(void)
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
 
     snprintf(req, sizeof(req), "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n");
 

--- a/t/http.c
+++ b/t/http.c
@@ -23,6 +23,7 @@ static int e2e_body_len = 0;
 static int e2e_body_handler(mln_http_t *http, mln_chain_t **body_head, mln_chain_t **body_tail)
 {
     mln_chain_t *c;
+    (void)http; (void)body_tail;
     e2e_body_len = 0;
     for (c = *body_head; c != NULL; c = c->next) {
         if (c->buf == NULL) continue;
@@ -40,20 +41,6 @@ static long elapsed_us(struct timespec *start, struct timespec *end)
     long sec_diff = (long)(end->tv_sec - start->tv_sec);
     long nsec_diff = (long)(end->tv_nsec - start->tv_nsec);
     return sec_diff * 1000000 + nsec_diff / 1000;
-}
-
-static mln_chain_t *create_chain_from_string(mln_alloc_t *pool, const char *str)
-{
-    mln_chain_t *c;
-    mln_buf_t *b;
-
-    assert((c = mln_chain_new(pool)) != NULL);
-    assert((b = mln_buf_new(pool)) != NULL);
-    c->buf = b;
-    b->start = b->pos = b->left_pos = (mln_u8ptr_t)(void *)str;
-    b->last = b->end = (mln_u8ptr_t)(void *)str + strlen(str);
-    b->temporary = 1;
-    return c;
 }
 
 static void test_request_parse_get(void)
@@ -191,7 +178,6 @@ static void test_http_versions(void)
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     snprintf(req, sizeof(req), "GET / HTTP/1.1\r\nHost: test.com\r\n\r\n");
 
@@ -333,8 +319,8 @@ static void test_response_status_codes(void)
     for (i = 0; i < 7; i++) {
         assert(mln_tcp_conn_init(&conn, -1) == 0);
         assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-        /* Do not pre-set type; parser auto-detects */
         pool = mln_tcp_conn_pool_get(&conn);
+        /* Do not pre-set type; parser auto-detects */
 
         snprintf(resp, sizeof(resp), "HTTP/1.1 %s\r\n\r\n", tests[i].msg);
 
@@ -419,14 +405,12 @@ static void test_generate_request(void)
 {
     mln_http_t *http;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *c, *head = NULL, *tail = NULL;
     mln_string_t key, val;
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
 
-    pool = mln_tcp_conn_pool_get(&conn);
 
     mln_http_type_set(http, M_HTTP_REQUEST);
     mln_http_method_set(http, M_HTTP_GET);
@@ -456,14 +440,12 @@ static void test_generate_response(void)
 {
     mln_http_t *http;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *c, *head = NULL, *tail = NULL;
     mln_string_t key, val;
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
 
-    pool = mln_tcp_conn_pool_get(&conn);
 
     mln_http_type_set(http, M_HTTP_RESPONSE);
     mln_http_status_set(http, M_HTTP_OK);
@@ -628,7 +610,6 @@ static void test_stability_generate_multiple(void)
 {
     mln_http_t *http;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *head, *tail;
     mln_string_t key, val;
     char val_str[256];
@@ -637,7 +618,6 @@ static void test_stability_generate_multiple(void)
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     mln_http_type_set(http, M_HTTP_RESPONSE);
     mln_http_version_set(http, M_HTTP_VERSION_1_1);

--- a/t/http.c
+++ b/t/http.c
@@ -4,7 +4,17 @@
 #include <assert.h>
 #include <time.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 #include "mln_http.h"
+
+static void set_nonblock(int fd)
+{
+    int flags = fcntl(fd, F_GETFL, 0);
+    assert(flags >= 0);
+    assert(fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0);
+}
 
 static long elapsed_us(struct timespec *start, struct timespec *end)
 {
@@ -641,6 +651,205 @@ static void test_stability_generate_multiple(void)
     mln_tcp_conn_destroy(&conn);
 }
 
+static void test_e2e_request_response(void)
+{
+    int fds[2];
+    mln_tcp_conn_t client_conn, server_conn;
+    mln_http_t *client_http, *server_http;
+    mln_chain_t *head, *tail, *c;
+    mln_string_t key, val;
+    int ret;
+
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]);
+    set_nonblock(fds[1]);
+
+    assert(mln_tcp_conn_init(&client_conn, fds[0]) == 0);
+    mln_tcp_conn_set_nonblock(&client_conn, 1);
+    assert((client_http = mln_http_init(&client_conn, NULL, NULL)) != NULL);
+
+    assert(mln_tcp_conn_init(&server_conn, fds[1]) == 0);
+    mln_tcp_conn_set_nonblock(&server_conn, 1);
+    assert((server_http = mln_http_init(&server_conn, NULL, NULL)) != NULL);
+
+    /* CLIENT: Generate HTTP GET request */
+    mln_http_type_set(client_http, M_HTTP_REQUEST);
+    mln_http_method_set(client_http, M_HTTP_GET);
+    mln_http_version_set(client_http, M_HTTP_VERSION_1_1);
+    mln_string_set(&key, "Host");
+    mln_string_set(&val, "127.0.0.1:8080");
+    assert(mln_http_field_set(client_http, &key, &val) == 0);
+
+    head = NULL; tail = NULL;
+    assert(mln_http_generate(client_http, &head, &tail) == M_HTTP_RET_DONE);
+    assert(head != NULL);
+    mln_tcp_conn_append_chain(&client_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&client_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* SERVER: Receive and parse request */
+    ret = mln_tcp_conn_recv(&server_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&server_conn, M_C_RECV);
+    assert(c != NULL);
+    ret = mln_http_parse(server_http, &c);
+    assert(ret == M_HTTP_RET_DONE);
+    assert(mln_http_method_get(server_http) == M_HTTP_GET);
+    assert(mln_http_type_get(server_http) == M_HTTP_REQUEST);
+    if (c != NULL) mln_chain_pool_release_all(c);
+
+    /* SERVER: Generate HTTP 200 OK response */
+    mln_http_reset(server_http);
+    mln_http_type_set(server_http, M_HTTP_RESPONSE);
+    mln_http_status_set(server_http, M_HTTP_OK);
+    mln_http_version_set(server_http, M_HTTP_VERSION_1_1);
+    mln_string_set(&key, "Content-Type");
+    mln_string_set(&val, "text/plain");
+    assert(mln_http_field_set(server_http, &key, &val) == 0);
+
+    head = NULL; tail = NULL;
+    assert(mln_http_generate(server_http, &head, &tail) == M_HTTP_RET_DONE);
+    assert(head != NULL);
+    mln_tcp_conn_append_chain(&server_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&server_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* CLIENT: Receive and parse response */
+    mln_http_reset(client_http);
+    ret = mln_tcp_conn_recv(&client_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&client_conn, M_C_RECV);
+    assert(c != NULL);
+    /* type is UNKNOWN after reset, parser auto-detects response from HTTP/1.1 prefix */
+    ret = mln_http_parse(client_http, &c);
+    assert(ret == M_HTTP_RET_DONE);
+    assert(mln_http_status_get(client_http) == M_HTTP_OK);
+    assert(mln_http_type_get(client_http) == M_HTTP_RESPONSE);
+    if (c != NULL) mln_chain_pool_release_all(c);
+
+    mln_http_destroy(client_http);
+    mln_http_destroy(server_http);
+    mln_tcp_conn_destroy(&client_conn);
+    mln_tcp_conn_destroy(&server_conn);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("[PASS] test_e2e_request_response\n");
+}
+
+static void test_e2e_post_with_body(void)
+{
+    int fds[2];
+    mln_tcp_conn_t client_conn, server_conn;
+    mln_http_t *client_http, *server_http;
+    mln_alloc_t *client_pool;
+    mln_chain_t *head, *tail, *c;
+    mln_string_t key, val;
+    const char *body_str = "hello";
+    int ret;
+
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]);
+    set_nonblock(fds[1]);
+
+    assert(mln_tcp_conn_init(&client_conn, fds[0]) == 0);
+    mln_tcp_conn_set_nonblock(&client_conn, 1);
+    assert((client_http = mln_http_init(&client_conn, NULL, NULL)) != NULL);
+    client_pool = mln_tcp_conn_pool_get(&client_conn);
+
+    assert(mln_tcp_conn_init(&server_conn, fds[1]) == 0);
+    mln_tcp_conn_set_nonblock(&server_conn, 1);
+    assert((server_http = mln_http_init(&server_conn, NULL, NULL)) != NULL);
+
+    /* CLIENT: Generate HTTP POST request headers */
+    mln_http_type_set(client_http, M_HTTP_REQUEST);
+    mln_http_method_set(client_http, M_HTTP_POST);
+    mln_http_version_set(client_http, M_HTTP_VERSION_1_1);
+
+    mln_string_set(&key, "Host");
+    mln_string_set(&val, "example.com");
+    assert(mln_http_field_set(client_http, &key, &val) == 0);
+    mln_string_set(&key, "Content-Length");
+    mln_string_set(&val, "5");
+    assert(mln_http_field_set(client_http, &key, &val) == 0);
+    mln_string_set(&key, "Content-Type");
+    mln_string_set(&val, "text/plain");
+    assert(mln_http_field_set(client_http, &key, &val) == 0);
+
+    head = NULL; tail = NULL;
+    assert(mln_http_generate(client_http, &head, &tail) == M_HTTP_RET_DONE);
+    assert(head != NULL);
+
+    /* CLIENT: Append body after headers.
+     * mln_http_generate may return tail=NULL, so walk chain to find real tail. */
+    mln_chain_t *body_chain;
+    mln_buf_t *body_buf;
+    assert((body_chain = mln_chain_new(client_pool)) != NULL);
+    assert((body_buf = mln_buf_new(client_pool)) != NULL);
+    body_chain->buf = body_buf;
+    body_buf->start = body_buf->pos = body_buf->left_pos = (mln_u8ptr_t)(void *)body_str;
+    body_buf->last = body_buf->end = (mln_u8ptr_t)(void *)body_str + strlen(body_str);
+    body_buf->temporary = 1;
+    body_buf->last_buf = 1;
+    body_buf->last_in_chain = 1;
+
+    /* Walk chain to find real tail, then append body */
+    mln_chain_t *real_tail = head;
+    while (real_tail->next != NULL) real_tail = real_tail->next;
+    real_tail->next = body_chain;
+    real_tail = body_chain;
+
+    mln_tcp_conn_append_chain(&client_conn, head, real_tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&client_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* SERVER: Receive and parse the POST request */
+    ret = mln_tcp_conn_recv(&server_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&server_conn, M_C_RECV);
+    assert(c != NULL);
+    ret = mln_http_parse(server_http, &c);
+    assert(ret == M_HTTP_RET_DONE);
+    assert(mln_http_method_get(server_http) == M_HTTP_POST);
+    if (c != NULL) mln_chain_pool_release_all(c);
+
+    /* SERVER: Generate HTTP 201 Created response */
+    mln_http_reset(server_http);
+    mln_http_type_set(server_http, M_HTTP_RESPONSE);
+    mln_http_status_set(server_http, M_HTTP_CREATED);
+    mln_http_version_set(server_http, M_HTTP_VERSION_1_1);
+    mln_string_set(&key, "Content-Type");
+    mln_string_set(&val, "application/json");
+    assert(mln_http_field_set(server_http, &key, &val) == 0);
+
+    head = NULL; tail = NULL;
+    assert(mln_http_generate(server_http, &head, &tail) == M_HTTP_RET_DONE);
+    assert(head != NULL);
+    mln_tcp_conn_append_chain(&server_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&server_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* CLIENT: Receive and parse response */
+    mln_http_reset(client_http);
+    ret = mln_tcp_conn_recv(&client_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&client_conn, M_C_RECV);
+    assert(c != NULL);
+    ret = mln_http_parse(client_http, &c);
+    assert(ret == M_HTTP_RET_DONE);
+    assert(mln_http_status_get(client_http) == M_HTTP_CREATED);
+    if (c != NULL) mln_chain_pool_release_all(c);
+
+    mln_http_destroy(client_http);
+    mln_http_destroy(server_http);
+    mln_tcp_conn_destroy(&client_conn);
+    mln_tcp_conn_destroy(&server_conn);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("[PASS] test_e2e_post_with_body\n");
+}
+
 int main(void)
 {
     printf("===== HTTP Module Tests =====\n\n");
@@ -674,6 +883,10 @@ int main(void)
     printf("\n=== Stability ===\n");
     test_stability_parse_multiple();
     test_stability_generate_multiple();
+
+    printf("\n=== E2E Socket Tests ===\n");
+    test_e2e_request_response();
+    test_e2e_post_with_body();
 
     printf("\n===== All tests passed! =====\n");
     return 0;

--- a/t/websocket.c
+++ b/t/websocket.c
@@ -23,20 +23,6 @@ static long elapsed_us(struct timespec *start, struct timespec *end)
     return sec_diff * 1000000 + nsec_diff / 1000;
 }
 
-static mln_chain_t *create_chain_from_string(mln_alloc_t *pool, const char *str)
-{
-    mln_chain_t *c;
-    mln_buf_t *b;
-
-    assert((c = mln_chain_new(pool)) != NULL);
-    assert((b = mln_buf_new(pool)) != NULL);
-    c->buf = b;
-    b->start = b->pos = b->left_pos = (mln_u8ptr_t)(void *)str;
-    b->last = b->end = (mln_u8ptr_t)(void *)str + strlen(str);
-    b->temporary = 1;
-    return c;
-}
-
 static void test_is_websocket_detection(void)
 {
     mln_http_t *http;
@@ -114,13 +100,11 @@ static void test_websocket_text_frame_generate_simple(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
     mln_u8_t data[] = "hello";
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
     mln_websocket_set_opcode(ws, M_WS_OPCODE_TEXT);
@@ -142,13 +126,11 @@ static void test_websocket_text_frame_client_mode(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
     mln_u8_t data[] = "test";
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
     mln_websocket_set_opcode(ws, M_WS_OPCODE_TEXT);
@@ -171,13 +153,11 @@ static void test_websocket_binary_frame_generate(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
     mln_u8_t data[] = {0x00, 0x01, 0x02, 0x03, 0x04};
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
     mln_websocket_set_opcode(ws, M_WS_OPCODE_BINARY);
@@ -199,12 +179,10 @@ static void test_websocket_close_frame_with_status(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
     mln_websocket_set_opcode(ws, M_WS_OPCODE_CLOSE);
@@ -227,12 +205,10 @@ static void test_websocket_ping_frame(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
     mln_websocket_set_opcode(ws, M_WS_OPCODE_PING);
@@ -254,12 +230,10 @@ static void test_websocket_pong_frame(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
     mln_websocket_set_opcode(ws, M_WS_OPCODE_PONG);
@@ -281,13 +255,11 @@ static void test_websocket_fragmentation_start(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
     mln_u8_t data[] = "fragment1";
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
     mln_websocket_set_opcode(ws, M_WS_OPCODE_TEXT);
@@ -309,13 +281,11 @@ static void test_websocket_fragmentation_continue(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
     mln_u8_t data[] = "fragment2";
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
     mln_websocket_set_opcode(ws, M_WS_OPCODE_CONTINUE);
@@ -337,13 +307,11 @@ static void test_websocket_fragmentation_end(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
     mln_u8_t data[] = "fragment3";
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
     mln_websocket_set_opcode(ws, M_WS_OPCODE_CONTINUE);
@@ -397,13 +365,11 @@ static void test_websocket_reset(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
     mln_u8_t data[] = "test";
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
 
@@ -605,7 +571,6 @@ static void test_websocket_performance_generate_parse_roundtrip(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
     mln_u8_t data[128];
     struct timespec start, end;
@@ -615,7 +580,6 @@ static void test_websocket_performance_generate_parse_roundtrip(void)
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
 
@@ -650,7 +614,6 @@ static void test_websocket_stability_large_frames(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
     mln_u8_t *data;
     int i;
@@ -659,7 +622,6 @@ static void test_websocket_stability_large_frames(void)
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
 
@@ -695,7 +657,6 @@ static void test_websocket_stability_mixed_frames(void)
     mln_http_t *http;
     mln_websocket_t *ws;
     mln_tcp_conn_t conn;
-    mln_alloc_t *pool;
     mln_chain_t *out = NULL;
     mln_u8_t data[] = "test payload";
     int i;
@@ -703,7 +664,6 @@ static void test_websocket_stability_mixed_frames(void)
 
     assert(mln_tcp_conn_init(&conn, -1) == 0);
     assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
-    pool = mln_tcp_conn_pool_get(&conn);
 
     assert((ws = mln_websocket_new(http)) != NULL);
 

--- a/t/websocket.c
+++ b/t/websocket.c
@@ -1,0 +1,797 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <time.h>
+#include "mln_websocket.h"
+#include "mln_http.h"
+
+static long elapsed_us(struct timespec *start, struct timespec *end)
+{
+    long sec_diff = (long)(end->tv_sec - start->tv_sec);
+    long nsec_diff = (long)(end->tv_nsec - start->tv_nsec);
+    return sec_diff * 1000000 + nsec_diff / 1000;
+}
+
+static mln_chain_t *create_chain_from_string(mln_alloc_t *pool, const char *str)
+{
+    mln_chain_t *c;
+    mln_buf_t *b;
+
+    assert((c = mln_chain_new(pool)) != NULL);
+    assert((b = mln_buf_new(pool)) != NULL);
+    c->buf = b;
+    b->start = b->pos = b->left_pos = (mln_u8ptr_t)(void *)str;
+    b->last = b->end = (mln_u8ptr_t)(void *)str + strlen(str);
+    b->temporary = 1;
+    return c;
+}
+
+static void test_is_websocket_detection(void)
+{
+    mln_http_t *http;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c;
+    mln_buf_t *b;
+    char req[] = "GET / HTTP/1.1\r\nHost: test.com\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((c = mln_chain_new(pool)) != NULL);
+    assert((b = mln_buf_new(pool)) != NULL);
+    c->buf = b;
+    b->start = b->pos = b->left_pos = (mln_u8ptr_t)req;
+    b->last = b->end = (mln_u8ptr_t)req + sizeof(req) - 1;
+    b->temporary = 1;
+
+    assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+
+    assert(mln_websocket_is_websocket(http) >= 0);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_is_websocket_detection\n");
+}
+
+static void test_websocket_init(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *c;
+    mln_buf_t *b;
+    char req[] = "GET / HTTP/1.1\r\nHost: test.com\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((c = mln_chain_new(pool)) != NULL);
+    assert((b = mln_buf_new(pool)) != NULL);
+    c->buf = b;
+    b->start = b->pos = b->left_pos = (mln_u8ptr_t)req;
+    b->last = b->end = (mln_u8ptr_t)req + sizeof(req) - 1;
+    b->temporary = 1;
+
+    assert(mln_http_parse(http, &c) == M_HTTP_RET_DONE);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    assert(mln_websocket_get_http(ws) == http);
+    assert(mln_websocket_get_pool(ws) != NULL);
+    assert(mln_websocket_get_connection(ws) != NULL);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_init\n");
+}
+
+static void test_websocket_text_frame_generate_simple(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+    mln_u8_t data[] = "hello";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+    mln_websocket_set_opcode(ws, M_WS_OPCODE_TEXT);
+    mln_websocket_set_fin(ws);
+
+    assert(mln_websocket_text_generate(ws, &out, data, sizeof(data) - 1, M_WS_FLAG_NONE) == M_WS_RET_OK);
+    assert(out != NULL);
+
+    mln_chain_pool_release_all(out);
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_text_frame_generate_simple\n");
+}
+
+static void test_websocket_text_frame_client_mode(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+    mln_u8_t data[] = "test";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+    mln_websocket_set_opcode(ws, M_WS_OPCODE_TEXT);
+    mln_websocket_set_fin(ws);
+    mln_websocket_set_maskbit(ws);
+
+    assert(mln_websocket_text_generate(ws, &out, data, sizeof(data) - 1, M_WS_FLAG_CLIENT) == M_WS_RET_OK);
+    assert(out != NULL);
+
+    mln_chain_pool_release_all(out);
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_text_frame_client_mode\n");
+}
+
+static void test_websocket_binary_frame_generate(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+    mln_u8_t data[] = {0x00, 0x01, 0x02, 0x03, 0x04};
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+    mln_websocket_set_opcode(ws, M_WS_OPCODE_BINARY);
+    mln_websocket_set_fin(ws);
+
+    assert(mln_websocket_binary_generate(ws, &out, data, sizeof(data), M_WS_FLAG_NONE) == M_WS_RET_OK);
+    assert(out != NULL);
+
+    mln_chain_pool_release_all(out);
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_binary_frame_generate\n");
+}
+
+static void test_websocket_close_frame_with_status(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+    mln_websocket_set_opcode(ws, M_WS_OPCODE_CLOSE);
+    mln_websocket_set_fin(ws);
+    mln_websocket_set_status(ws, M_WS_STATUS_NORMAL_CLOSURE);
+
+    assert(mln_websocket_close_generate(ws, &out, "Goodbye", 7, M_WS_FLAG_NONE) == M_WS_RET_OK);
+    assert(out != NULL);
+
+    mln_chain_pool_release_all(out);
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_close_frame_with_status\n");
+}
+
+static void test_websocket_ping_frame(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+    mln_websocket_set_opcode(ws, M_WS_OPCODE_PING);
+    mln_websocket_set_fin(ws);
+
+    assert(mln_websocket_ping_generate(ws, &out, M_WS_FLAG_NONE) == M_WS_RET_OK);
+    assert(out != NULL);
+
+    mln_chain_pool_release_all(out);
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_ping_frame\n");
+}
+
+static void test_websocket_pong_frame(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+    mln_websocket_set_opcode(ws, M_WS_OPCODE_PONG);
+    mln_websocket_set_fin(ws);
+
+    assert(mln_websocket_pong_generate(ws, &out, M_WS_FLAG_NONE) == M_WS_RET_OK);
+    assert(out != NULL);
+
+    mln_chain_pool_release_all(out);
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_pong_frame\n");
+}
+
+static void test_websocket_fragmentation_start(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+    mln_u8_t data[] = "fragment1";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+    mln_websocket_set_opcode(ws, M_WS_OPCODE_TEXT);
+    mln_websocket_reset_fin(ws);
+
+    assert(mln_websocket_text_generate(ws, &out, data, sizeof(data) - 1, M_WS_FLAG_NEW) == M_WS_RET_OK);
+    assert(out != NULL);
+
+    mln_chain_pool_release_all(out);
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_fragmentation_start\n");
+}
+
+static void test_websocket_fragmentation_continue(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+    mln_u8_t data[] = "fragment2";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+    mln_websocket_set_opcode(ws, M_WS_OPCODE_CONTINUE);
+    mln_websocket_reset_fin(ws);
+
+    assert(mln_websocket_text_generate(ws, &out, data, sizeof(data) - 1, M_WS_FLAG_NONE) == M_WS_RET_OK);
+    assert(out != NULL);
+
+    mln_chain_pool_release_all(out);
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_fragmentation_continue\n");
+}
+
+static void test_websocket_fragmentation_end(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+    mln_u8_t data[] = "fragment3";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+    mln_websocket_set_opcode(ws, M_WS_OPCODE_CONTINUE);
+    mln_websocket_set_fin(ws);
+
+    assert(mln_websocket_text_generate(ws, &out, data, sizeof(data) - 1, M_WS_FLAG_END) == M_WS_RET_OK);
+    assert(out != NULL);
+
+    mln_chain_pool_release_all(out);
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_fragmentation_end\n");
+}
+
+static void test_websocket_field_operations(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_string_t key, val, val2;
+    mln_string_t *result;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    mln_string_set(&key, "X-Custom-Header");
+    mln_string_set(&val, "CustomValue");
+    mln_string_set(&val2, "NewValue");
+
+    assert(mln_websocket_set_field(ws, &key, &val) == 0);
+    result = mln_websocket_get_field(ws, &key);
+    assert(result != NULL);
+
+    assert(mln_websocket_set_field(ws, &key, &val2) == 0);
+    result = mln_websocket_get_field(ws, &key);
+    assert(result != NULL);
+
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_field_operations\n");
+}
+
+static void test_websocket_reset(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+    mln_u8_t data[] = "test";
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    mln_websocket_set_opcode(ws, M_WS_OPCODE_TEXT);
+    mln_websocket_set_fin(ws);
+    assert(mln_websocket_text_generate(ws, &out, data, sizeof(data) - 1, M_WS_FLAG_NONE) == M_WS_RET_OK);
+
+    mln_chain_pool_release_all(out);
+    mln_websocket_reset(ws);
+
+    assert(mln_websocket_get_opcode(ws) == 0);
+    assert(mln_websocket_get_fin(ws) == 0);
+
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_reset\n");
+}
+
+static void test_websocket_masking_operations(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_u32_t mask_key = 0x12345678;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    mln_websocket_set_masking_key(ws, mask_key);
+    assert(mln_websocket_get_masking_key(ws) == mask_key);
+
+    mln_websocket_set_maskbit(ws);
+    assert(mln_websocket_get_maskbit(ws) == 1);
+
+    mln_websocket_reset_maskbit(ws);
+    assert(mln_websocket_get_maskbit(ws) == 0);
+
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_masking_operations\n");
+}
+
+static void test_websocket_rsv_bits(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    mln_websocket_set_rsv1(ws);
+    assert(mln_websocket_get_rsv1(ws) == 1);
+    mln_websocket_reset_rsv1(ws);
+    assert(mln_websocket_get_rsv1(ws) == 0);
+
+    mln_websocket_set_rsv2(ws);
+    assert(mln_websocket_get_rsv2(ws) == 1);
+    mln_websocket_reset_rsv2(ws);
+    assert(mln_websocket_get_rsv2(ws) == 0);
+
+    mln_websocket_set_rsv3(ws);
+    assert(mln_websocket_get_rsv3(ws) == 1);
+    mln_websocket_reset_rsv3(ws);
+    assert(mln_websocket_get_rsv3(ws) == 0);
+
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_rsv_bits\n");
+}
+
+static void test_websocket_content_operations(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    void *test_data = (void *)0xdeadbeef;
+    mln_u64_t content_len = 1024;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    mln_websocket_set_content(ws, test_data);
+    assert(mln_websocket_get_content(ws) == test_data);
+
+    mln_websocket_set_content_len(ws, content_len);
+    assert(mln_websocket_get_content_len(ws) == content_len);
+
+    mln_websocket_set_content_free(ws);
+    assert(mln_websocket_get_content_free(ws) == 1);
+
+    mln_websocket_reset_content_free(ws);
+    assert(mln_websocket_get_content_free(ws) == 0);
+
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_content_operations\n");
+}
+
+static void test_websocket_status_codes(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    mln_websocket_set_status(ws, M_WS_STATUS_NORMAL_CLOSURE);
+    assert(mln_websocket_get_status(ws) == M_WS_STATUS_NORMAL_CLOSURE);
+
+    mln_websocket_set_status(ws, M_WS_STATUS_GOING_AWAY);
+    assert(mln_websocket_get_status(ws) == M_WS_STATUS_GOING_AWAY);
+
+    mln_websocket_set_status(ws, M_WS_STATUS_PROTOCOL_ERROR);
+    assert(mln_websocket_get_status(ws) == M_WS_STATUS_PROTOCOL_ERROR);
+
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_status_codes\n");
+}
+
+static void test_websocket_uri_args_operations(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_string_t test_uri, test_args;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    mln_string_set(&test_uri, "/ws");
+    mln_string_set(&test_args, "token=abc123");
+
+    /* Must use pool-duplicated strings since websocket_destroy frees them */
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&conn);
+    mln_string_t *dup_uri = mln_string_pool_dup(pool, &test_uri);
+    mln_string_t *dup_args = mln_string_pool_dup(pool, &test_args);
+    assert(dup_uri != NULL && dup_args != NULL);
+
+    mln_websocket_set_uri(ws, dup_uri);
+    assert(mln_websocket_get_uri(ws) != NULL);
+
+    mln_websocket_set_args(ws, dup_args);
+    assert(mln_websocket_get_args(ws) != NULL);
+
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_uri_args_operations\n");
+}
+
+static void test_websocket_data_operations(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    void *user_data = (void *)0xcafebabe;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    mln_websocket_set_data(ws, user_data);
+    assert(mln_websocket_get_data(ws) == user_data);
+
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_data_operations\n");
+}
+
+static void test_websocket_performance_generate_parse_roundtrip(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+    mln_u8_t data[128];
+    struct timespec start, end;
+    long elapsed;
+    int i;
+    int iterations = 100000;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    memset(data, 'A', sizeof(data));
+
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    for (i = 0; i < iterations; i++) {
+        mln_websocket_set_opcode(ws, M_WS_OPCODE_TEXT);
+        mln_websocket_set_fin(ws);
+
+        assert(mln_websocket_text_generate(ws, &out, data, sizeof(data), M_WS_FLAG_NONE) == M_WS_RET_OK);
+
+        mln_chain_pool_release_all(out);
+        out = NULL;
+        mln_websocket_reset(ws);
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    elapsed = elapsed_us(&start, &end);
+
+    printf("[PERF] websocket generate: %d iterations in %ld us (%.2f ops/sec)\n",
+           iterations, elapsed, (iterations * 1000000.0) / elapsed);
+
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+}
+
+static void test_websocket_stability_large_frames(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+    mln_u8_t *data;
+    int i;
+    int count = 10000;
+    int data_size = 256;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    assert((data = (mln_u8_t *)malloc(data_size)) != NULL);
+    memset(data, 0x42, data_size);
+
+    for (i = 0; i < count; i++) {
+        mln_websocket_set_opcode(ws, (i % 2 == 0) ? M_WS_OPCODE_TEXT : M_WS_OPCODE_BINARY);
+        mln_websocket_set_fin(ws);
+
+        if (i % 2 == 0) {
+            assert(mln_websocket_text_generate(ws, &out, data, data_size, M_WS_FLAG_NONE) == M_WS_RET_OK);
+        } else {
+            assert(mln_websocket_binary_generate(ws, &out, data, data_size, M_WS_FLAG_NONE) == M_WS_RET_OK);
+        }
+
+        assert(out != NULL);
+        mln_chain_pool_release_all(out);
+        out = NULL;
+        mln_websocket_reset(ws);
+    }
+
+    free(data);
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_stability_large_frames (%d frames)\n", count);
+}
+
+static void test_websocket_stability_mixed_frames(void)
+{
+    mln_http_t *http;
+    mln_websocket_t *ws;
+    mln_tcp_conn_t conn;
+    mln_alloc_t *pool;
+    mln_chain_t *out = NULL;
+    mln_u8_t data[] = "test payload";
+    int i;
+    int count = 10000;
+
+    assert(mln_tcp_conn_init(&conn, -1) == 0);
+    assert((http = mln_http_init(&conn, NULL, NULL)) != NULL);
+    pool = mln_tcp_conn_pool_get(&conn);
+
+    assert((ws = mln_websocket_new(http)) != NULL);
+
+    for (i = 0; i < count; i++) {
+        int frame_type = i % 6;
+
+        mln_websocket_reset(ws);
+        mln_websocket_set_fin(ws);
+
+        switch (frame_type) {
+            case 0:
+                mln_websocket_set_opcode(ws, M_WS_OPCODE_TEXT);
+                assert(mln_websocket_text_generate(ws, &out, data, sizeof(data) - 1, M_WS_FLAG_NONE) == M_WS_RET_OK);
+                break;
+            case 1:
+                mln_websocket_set_opcode(ws, M_WS_OPCODE_BINARY);
+                assert(mln_websocket_binary_generate(ws, &out, data, sizeof(data) - 1, M_WS_FLAG_NONE) == M_WS_RET_OK);
+                break;
+            case 2:
+                mln_websocket_set_opcode(ws, M_WS_OPCODE_PING);
+                assert(mln_websocket_ping_generate(ws, &out, M_WS_FLAG_NONE) == M_WS_RET_OK);
+                break;
+            case 3:
+                mln_websocket_set_opcode(ws, M_WS_OPCODE_PONG);
+                assert(mln_websocket_pong_generate(ws, &out, M_WS_FLAG_NONE) == M_WS_RET_OK);
+                break;
+            case 4:
+                mln_websocket_set_opcode(ws, M_WS_OPCODE_CLOSE);
+                mln_websocket_set_status(ws, M_WS_STATUS_NORMAL_CLOSURE);
+                assert(mln_websocket_close_generate(ws, &out, "", 0, M_WS_FLAG_NONE) == M_WS_RET_OK);
+                break;
+            case 5:
+                mln_websocket_set_opcode(ws, M_WS_OPCODE_TEXT);
+                mln_websocket_reset_fin(ws);
+                assert(mln_websocket_text_generate(ws, &out, data, sizeof(data) - 1, M_WS_FLAG_NEW) == M_WS_RET_OK);
+                break;
+        }
+
+        assert(out != NULL);
+        mln_chain_pool_release_all(out);
+        out = NULL;
+    }
+
+    mln_websocket_free(ws);
+    mln_http_destroy(http);
+    mln_tcp_conn_destroy(&conn);
+
+    printf("[PASS] test_websocket_stability_mixed_frames (%d frames)\n", count);
+}
+
+int main(void)
+{
+    printf("===== WebSocket Module Tests =====\n\n");
+
+    printf("=== WebSocket Detection and Init ===\n");
+    test_is_websocket_detection();
+    test_websocket_init();
+
+    printf("\n=== Frame Generation ===\n");
+    test_websocket_text_frame_generate_simple();
+    test_websocket_text_frame_client_mode();
+    test_websocket_binary_frame_generate();
+    test_websocket_close_frame_with_status();
+    test_websocket_ping_frame();
+    test_websocket_pong_frame();
+
+    printf("\n=== Fragmentation ===\n");
+    test_websocket_fragmentation_start();
+    test_websocket_fragmentation_continue();
+    test_websocket_fragmentation_end();
+
+    printf("\n=== Field Operations ===\n");
+    test_websocket_field_operations();
+    test_websocket_reset();
+
+    printf("\n=== Masking Operations ===\n");
+    test_websocket_masking_operations();
+
+    printf("\n=== RSV Bits ===\n");
+    test_websocket_rsv_bits();
+
+    printf("\n=== Content Operations ===\n");
+    test_websocket_content_operations();
+    test_websocket_status_codes();
+
+    printf("\n=== URI and Args Operations ===\n");
+    test_websocket_uri_args_operations();
+
+    printf("\n=== Data Operations ===\n");
+    test_websocket_data_operations();
+
+    printf("\n=== Performance ===\n");
+    test_websocket_performance_generate_parse_roundtrip();
+
+    printf("\n=== Stability ===\n");
+    test_websocket_stability_large_frames();
+    test_websocket_stability_mixed_frames();
+
+    printf("\n===== All WebSocket tests passed! =====\n");
+    return 0;
+}

--- a/t/websocket.c
+++ b/t/websocket.c
@@ -3,8 +3,18 @@
 #include <string.h>
 #include <assert.h>
 #include <time.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/socket.h>
 #include "mln_websocket.h"
 #include "mln_http.h"
+
+static void set_nonblock(int fd)
+{
+    int flags = fcntl(fd, F_GETFL, 0);
+    assert(flags >= 0);
+    assert(fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0);
+}
 
 static long elapsed_us(struct timespec *start, struct timespec *end)
 {
@@ -744,6 +754,407 @@ static void test_websocket_stability_mixed_frames(void)
     printf("[PASS] test_websocket_stability_mixed_frames (%d frames)\n", count);
 }
 
+static void test_e2e_text_echo(void)
+{
+    int socks[2];
+    mln_tcp_conn_t client_conn, server_conn;
+    mln_http_t *client_http, *server_http;
+    mln_websocket_t *client_ws, *server_ws;
+    mln_chain_t *head, *tail;
+    mln_chain_t *c;
+    mln_u8_t data[] = "Hello WebSocket";
+    int ret;
+
+    /* Create non-blocking socket pair */
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, socks) == 0);
+    set_nonblock(socks[0]);
+    set_nonblock(socks[1]);
+
+    /* Client side: generate handshake request */
+    assert(mln_tcp_conn_init(&client_conn, socks[0]) == 0);
+    mln_tcp_conn_set_nonblock(&client_conn, 1);
+    assert((client_http = mln_http_init(&client_conn, NULL, NULL)) != NULL);
+    assert((client_ws = mln_websocket_new(client_http)) != NULL);
+
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_handshake_request_generate(client_ws, &head, &tail) == M_WS_RET_OK);
+    assert(head != NULL);
+
+    mln_tcp_conn_append_chain(&client_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&client_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Server side: recv and parse HTTP request */
+    assert(mln_tcp_conn_init(&server_conn, socks[1]) == 0);
+    mln_tcp_conn_set_nonblock(&server_conn, 1);
+    assert((server_http = mln_http_init(&server_conn, NULL, NULL)) != NULL);
+
+    ret = mln_tcp_conn_recv(&server_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&server_conn, M_C_RECV);
+    assert(c != NULL);
+
+    assert(mln_http_parse(server_http, &c) == M_HTTP_RET_DONE);
+    assert(mln_websocket_is_websocket(server_http) >= 0);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    /* Server: generate handshake response */
+    assert((server_ws = mln_websocket_new(server_http)) != NULL);
+
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_handshake_response_generate(server_ws, &head, &tail) == M_WS_RET_OK);
+    assert(head != NULL);
+
+    mln_tcp_conn_append_chain(&server_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&server_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Client side: recv handshake response */
+    mln_http_reset(client_http);
+    ret = mln_tcp_conn_recv(&client_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&client_conn, M_C_RECV);
+    assert(c != NULL);
+
+    assert(mln_http_parse(client_http, &c) == M_HTTP_RET_DONE);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    /* Client: generate text frame with CLIENT flag */
+    mln_websocket_reset(client_ws);
+    mln_websocket_set_opcode(client_ws, M_WS_OPCODE_TEXT);
+    mln_websocket_set_fin(client_ws);
+    mln_websocket_set_maskbit(client_ws);
+
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_text_generate(client_ws, &head, data, sizeof(data) - 1, M_WS_FLAG_NEW | M_WS_FLAG_END | M_WS_FLAG_CLIENT) == M_WS_RET_OK);
+    assert(head != NULL);
+
+    mln_tcp_conn_append_chain(&client_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&client_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Server: recv and parse text frame */
+    mln_websocket_reset(server_ws);
+    ret = mln_tcp_conn_recv(&server_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&server_conn, M_C_RECV);
+    assert(c != NULL);
+
+    assert(mln_websocket_parse(server_ws, &c) == M_WS_RET_OK);
+    assert(mln_websocket_get_opcode(server_ws) == M_WS_OPCODE_TEXT);
+    assert(mln_websocket_get_content_len(server_ws) == sizeof(data) - 1);
+    assert(memcmp(mln_websocket_get_content(server_ws), data, sizeof(data) - 1) == 0);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    /* Server: generate echo response with SERVER flag */
+    mln_websocket_reset(server_ws);
+    mln_websocket_set_opcode(server_ws, M_WS_OPCODE_TEXT);
+    mln_websocket_set_fin(server_ws);
+
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_text_generate(server_ws, &head, data, sizeof(data) - 1, M_WS_FLAG_NEW | M_WS_FLAG_END | M_WS_FLAG_SERVER) == M_WS_RET_OK);
+    assert(head != NULL);
+
+    mln_tcp_conn_append_chain(&server_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&server_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Client: recv and parse echo response */
+    mln_websocket_reset(client_ws);
+    ret = mln_tcp_conn_recv(&client_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&client_conn, M_C_RECV);
+    assert(c != NULL);
+
+    assert(mln_websocket_parse(client_ws, &c) == M_WS_RET_OK);
+    assert(mln_websocket_get_opcode(client_ws) == M_WS_OPCODE_TEXT);
+    assert(mln_websocket_get_content_len(client_ws) == sizeof(data) - 1);
+    assert(memcmp(mln_websocket_get_content(client_ws), data, sizeof(data) - 1) == 0);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    /* Cleanup */
+    mln_websocket_free(client_ws);
+    mln_http_destroy(client_http);
+    mln_tcp_conn_destroy(&client_conn);
+
+    mln_websocket_free(server_ws);
+    mln_http_destroy(server_http);
+    mln_tcp_conn_destroy(&server_conn);
+
+    close(socks[0]);
+    close(socks[1]);
+
+    printf("[PASS] test_e2e_text_echo\n");
+}
+
+static void test_e2e_ping_pong(void)
+{
+    int socks[2];
+    mln_tcp_conn_t client_conn, server_conn;
+    mln_http_t *client_http, *server_http;
+    mln_websocket_t *client_ws, *server_ws;
+    mln_chain_t *head, *tail;
+    mln_chain_t *c;
+    int ret;
+
+    /* Create non-blocking socket pair */
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, socks) == 0);
+    set_nonblock(socks[0]);
+    set_nonblock(socks[1]);
+
+    /* Setup client */
+    assert(mln_tcp_conn_init(&client_conn, socks[0]) == 0);
+    mln_tcp_conn_set_nonblock(&client_conn, 1);
+    assert((client_http = mln_http_init(&client_conn, NULL, NULL)) != NULL);
+    assert((client_ws = mln_websocket_new(client_http)) != NULL);
+
+    /* Client handshake request */
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_handshake_request_generate(client_ws, &head, &tail) == M_WS_RET_OK);
+    mln_tcp_conn_append_chain(&client_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&client_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Setup server */
+    assert(mln_tcp_conn_init(&server_conn, socks[1]) == 0);
+    mln_tcp_conn_set_nonblock(&server_conn, 1);
+    assert((server_http = mln_http_init(&server_conn, NULL, NULL)) != NULL);
+
+    /* Server recv and parse */
+    ret = mln_tcp_conn_recv(&server_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&server_conn, M_C_RECV);
+    assert(c != NULL);
+    assert(mln_http_parse(server_http, &c) == M_HTTP_RET_DONE);
+    if (c != NULL) mln_chain_pool_release(c);
+
+    assert((server_ws = mln_websocket_new(server_http)) != NULL);
+
+    /* Server handshake response */
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_handshake_response_generate(server_ws, &head, &tail) == M_WS_RET_OK);
+    mln_tcp_conn_append_chain(&server_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&server_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Client recv response */
+    mln_http_reset(client_http);
+    ret = mln_tcp_conn_recv(&client_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&client_conn, M_C_RECV);
+    assert(c != NULL);
+    assert(mln_http_parse(client_http, &c) == M_HTTP_RET_DONE);
+    if (c != NULL) mln_chain_pool_release(c);
+
+    /* Client: generate ping frame */
+    mln_websocket_reset(client_ws);
+    mln_websocket_set_opcode(client_ws, M_WS_OPCODE_PING);
+    mln_websocket_set_fin(client_ws);
+    mln_websocket_set_maskbit(client_ws);
+
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_ping_generate(client_ws, &head, M_WS_FLAG_CLIENT) == M_WS_RET_OK);
+    assert(head != NULL);
+
+    mln_tcp_conn_append_chain(&client_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&client_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Server: recv and parse ping */
+    mln_websocket_reset(server_ws);
+    ret = mln_tcp_conn_recv(&server_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&server_conn, M_C_RECV);
+    assert(c != NULL);
+
+    assert(mln_websocket_parse(server_ws, &c) == M_WS_RET_OK);
+    assert(mln_websocket_get_opcode(server_ws) == M_WS_OPCODE_PING);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    /* Server: generate pong response */
+    mln_websocket_reset(server_ws);
+    mln_websocket_set_opcode(server_ws, M_WS_OPCODE_PONG);
+    mln_websocket_set_fin(server_ws);
+
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_pong_generate(server_ws, &head, M_WS_FLAG_SERVER) == M_WS_RET_OK);
+    assert(head != NULL);
+
+    mln_tcp_conn_append_chain(&server_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&server_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Client: recv and parse pong */
+    mln_websocket_reset(client_ws);
+    ret = mln_tcp_conn_recv(&client_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&client_conn, M_C_RECV);
+    assert(c != NULL);
+
+    assert(mln_websocket_parse(client_ws, &c) == M_WS_RET_OK);
+    assert(mln_websocket_get_opcode(client_ws) == M_WS_OPCODE_PONG);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    /* Cleanup */
+    mln_websocket_free(client_ws);
+    mln_http_destroy(client_http);
+    mln_tcp_conn_destroy(&client_conn);
+
+    mln_websocket_free(server_ws);
+    mln_http_destroy(server_http);
+    mln_tcp_conn_destroy(&server_conn);
+
+    close(socks[0]);
+    close(socks[1]);
+
+    printf("[PASS] test_e2e_ping_pong\n");
+}
+
+static void test_e2e_close_handshake(void)
+{
+    int socks[2];
+    mln_tcp_conn_t client_conn, server_conn;
+    mln_http_t *client_http, *server_http;
+    mln_websocket_t *client_ws, *server_ws;
+    mln_chain_t *head, *tail;
+    mln_chain_t *c;
+    int ret;
+
+    /* Create non-blocking socket pair */
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, socks) == 0);
+    set_nonblock(socks[0]);
+    set_nonblock(socks[1]);
+
+    /* Setup client */
+    assert(mln_tcp_conn_init(&client_conn, socks[0]) == 0);
+    mln_tcp_conn_set_nonblock(&client_conn, 1);
+    assert((client_http = mln_http_init(&client_conn, NULL, NULL)) != NULL);
+    assert((client_ws = mln_websocket_new(client_http)) != NULL);
+
+    /* Client handshake request */
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_handshake_request_generate(client_ws, &head, &tail) == M_WS_RET_OK);
+    mln_tcp_conn_append_chain(&client_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&client_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Setup server */
+    assert(mln_tcp_conn_init(&server_conn, socks[1]) == 0);
+    mln_tcp_conn_set_nonblock(&server_conn, 1);
+    assert((server_http = mln_http_init(&server_conn, NULL, NULL)) != NULL);
+
+    /* Server recv and parse */
+    ret = mln_tcp_conn_recv(&server_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&server_conn, M_C_RECV);
+    assert(c != NULL);
+    assert(mln_http_parse(server_http, &c) == M_HTTP_RET_DONE);
+    if (c != NULL) mln_chain_pool_release(c);
+
+    assert((server_ws = mln_websocket_new(server_http)) != NULL);
+
+    /* Server handshake response */
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_handshake_response_generate(server_ws, &head, &tail) == M_WS_RET_OK);
+    mln_tcp_conn_append_chain(&server_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&server_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Client recv response */
+    mln_http_reset(client_http);
+    ret = mln_tcp_conn_recv(&client_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&client_conn, M_C_RECV);
+    assert(c != NULL);
+    assert(mln_http_parse(client_http, &c) == M_HTTP_RET_DONE);
+    if (c != NULL) mln_chain_pool_release(c);
+
+    /* Client: generate close frame with status */
+    mln_websocket_reset(client_ws);
+    mln_websocket_set_opcode(client_ws, M_WS_OPCODE_CLOSE);
+    mln_websocket_set_fin(client_ws);
+    mln_websocket_set_status(client_ws, M_WS_STATUS_NORMAL_CLOSURE);
+    mln_websocket_set_maskbit(client_ws);
+
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_close_generate(client_ws, &head, "", 0, M_WS_FLAG_CLIENT) == M_WS_RET_OK);
+    assert(head != NULL);
+
+    mln_tcp_conn_append_chain(&client_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&client_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Server: recv and parse close frame */
+    mln_websocket_reset(server_ws);
+    ret = mln_tcp_conn_recv(&server_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&server_conn, M_C_RECV);
+    assert(c != NULL);
+
+    assert(mln_websocket_parse(server_ws, &c) == M_WS_RET_OK);
+    assert(mln_websocket_get_opcode(server_ws) == M_WS_OPCODE_CLOSE);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    /* Server: generate close frame response */
+    mln_websocket_reset(server_ws);
+    mln_websocket_set_opcode(server_ws, M_WS_OPCODE_CLOSE);
+    mln_websocket_set_fin(server_ws);
+    mln_websocket_set_status(server_ws, M_WS_STATUS_NORMAL_CLOSURE);
+
+    head = NULL;
+    tail = NULL;
+    assert(mln_websocket_close_generate(server_ws, &head, "", 0, M_WS_FLAG_SERVER) == M_WS_RET_OK);
+    assert(head != NULL);
+
+    mln_tcp_conn_append_chain(&server_conn, head, tail, M_C_SEND);
+    ret = mln_tcp_conn_send(&server_conn);
+    assert(ret == M_C_FINISH || ret == M_C_NOTYET);
+
+    /* Client: recv and parse close response */
+    mln_websocket_reset(client_ws);
+    ret = mln_tcp_conn_recv(&client_conn, M_C_TYPE_MEMORY);
+    assert(ret == M_C_NOTYET || ret == M_C_FINISH);
+    c = mln_tcp_conn_remove(&client_conn, M_C_RECV);
+    assert(c != NULL);
+
+    assert(mln_websocket_parse(client_ws, &c) == M_WS_RET_OK);
+    assert(mln_websocket_get_opcode(client_ws) == M_WS_OPCODE_CLOSE);
+
+    if (c != NULL) mln_chain_pool_release(c);
+
+    /* Cleanup */
+    mln_websocket_free(client_ws);
+    mln_http_destroy(client_http);
+    mln_tcp_conn_destroy(&client_conn);
+
+    mln_websocket_free(server_ws);
+    mln_http_destroy(server_http);
+    mln_tcp_conn_destroy(&server_conn);
+
+    close(socks[0]);
+    close(socks[1]);
+
+    printf("[PASS] test_e2e_close_handshake\n");
+}
+
 int main(void)
 {
     printf("===== WebSocket Module Tests =====\n\n");
@@ -791,6 +1202,11 @@ int main(void)
     printf("\n=== Stability ===\n");
     test_websocket_stability_large_frames();
     test_websocket_stability_mixed_frames();
+
+    printf("\n=== E2E Socket Tests ===\n");
+    test_e2e_text_echo();
+    test_e2e_ping_pong();
+    test_e2e_close_handshake();
 
     printf("\n===== All WebSocket tests passed! =====\n");
     return 0;


### PR DESCRIPTION
- chain: inline mln_buf_new, add mln_chain_new_with_buf combined allocator
- connection: cache nonblock flag, increase buffer sizes, add batch move_sent and send_chain APIs
- http: FNV-1a header hash, memchr line scanning, zero-copy single-buffer parsing, status code lookup table, fix HEAD method dispatch
- websocket: 4-byte XOR unmasking, RSV/control frame/close status validation per RFC 6455, fix memory leak in mln_websocket_new, fix extension token null terminator
- tests: comprehensive tests for all 4 modules covering features, performance, and stability

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
[https://github.com/Water-Melon/Melon/blob/master/CONTRIBUTING.md#contributing](https://github.com/Water-Melon/Melon/blob/master/CONTRIBUTING.md#contributing)
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
