### PR TITLE
perf(span): chunked pool and stack for ~3x speedup

### DIFF
--- a/docs/book/cn/span.md
+++ b/docs/book/cn/span.md
@@ -81,7 +81,7 @@ mln_span_stop();
 mln_span_release();
 ```
 
-描述：释放本次测量的测量值结构。**注意：**这个宏函数应在`mln_span_stop`之后被调用，否则将可能出现内存访问异常。
+描述：释放本次测量的测量值结构及内部内存池。**注意：**这个宏函数应在`mln_span_stop`之后被调用，否则将可能出现内存访问异常。
 
 返回值：无
 
@@ -93,9 +93,21 @@ mln_span_release();
 mln_span_move();
 ```
 
-描述：获取本次测量的测量值结构，并将指向该结构的全局指针置`NULL`。**注意：**这个宏函数应在`mln_span_stop`之后被调用，否则将出现不可预知的错误。
+描述：获取本次测量的测量值结构，并将指向该结构的全局指针置`NULL`。**注意：**这个宏函数应在`mln_span_stop`之后被调用，否则将出现不可预知的错误。使用`mln_span_move`获取到的`mln_span_t`结构在使用完毕后，应先调用`mln_span_free`释放它，然后调用`mln_span_pool_free`释放内部内存池。
 
 返回值：`mln_span_t`指针
+
+
+
+#### mln_span_pool_free
+
+```c
+void mln_span_pool_free(void);
+```
+
+描述：释放内部使用的内存池和栈缓冲区。该函数会在`mln_span_release`中被自动调用。如果使用`mln_span_move`获取了测量结构，在调用`mln_span_free`释放后，需要手动调用此函数释放内存池。
+
+返回值：无
 
 
 

--- a/docs/book/en/span.md
+++ b/docs/book/en/span.md
@@ -81,7 +81,7 @@ Return value: None
 mln_span_release();
 ```
 
-Description: Release the structure containing the measured values for this measurement. **Note**: This macro function should be called after `mln_span_stop`, otherwise, it may lead to memory access exceptions.
+Description: Release the structure containing the measured values for this measurement and the internal memory pool. **Note**: This macro function should be called after `mln_span_stop`, otherwise, it may lead to memory access exceptions.
 
 Return value: None
 
@@ -93,9 +93,21 @@ Return value: None
 mln_span_move();
 ```
 
-Description: Retrieve the structure containing the measured values for this measurement and set the global pointer pointing to this structure to `NULL`. **Note**: This macro function should be called after `mln_span_stop`, otherwise, unpredictable errors may occur.
+Description: Retrieve the structure containing the measured values for this measurement and set the global pointer pointing to this structure to `NULL`. **Note**: This macro function should be called after `mln_span_stop`, otherwise, unpredictable errors may occur. After using the returned `mln_span_t` structure, call `mln_span_free` to free it, then call `mln_span_pool_free` to release the internal memory pool.
 
 Return value: Pointer to `mln_span_t`
+
+
+
+#### mln_span_pool_free
+
+```c
+void mln_span_pool_free(void);
+```
+
+Description: Release the internal memory pool and stack buffers. This function is called automatically by `mln_span_release`. If you use `mln_span_move` to retrieve the measurement structure, you need to call this function manually after calling `mln_span_free` to release the internal memory pool.
+
+Return value: None
 
 
 

--- a/include/mln_span.h
+++ b/include/mln_span.h
@@ -27,16 +27,9 @@ typedef struct mln_span_s {
     struct mln_span_s            *next;
 } mln_span_t;
 
-typedef struct mln_span_stack_node_s {
-    mln_span_t                   *span;
-    struct mln_span_stack_node_s *next;
-} mln_span_stack_node_t;
-
 typedef void (*mln_span_dump_cb_t)(mln_span_t *s, int level, void *data);
 
 
-extern mln_span_stack_node_t *__mln_span_stack_top;
-extern mln_span_stack_node_t *__mln_span_stack_bottom;
 extern mln_span_t *mln_span_root;
 #if defined(MSVC)
 extern DWORD mln_span_registered_thread;
@@ -45,6 +38,7 @@ extern pthread_t mln_span_registered_thread;
 #endif
 
 extern void mln_span_stack_free(void);
+extern void mln_span_pool_free(void);
 extern mln_span_t *mln_span_new(mln_span_t *parent, const char *file, const char *func, int line);
 extern void mln_span_free(mln_span_t *s);
 extern int mln_span_entry(void *fptr, const char *file, const char *func, int line, ...);
@@ -52,27 +46,27 @@ extern void mln_span_exit(void *fptr, const char *file, const char *func, int li
 
 #if defined(MSVC)
 #define mln_span_start() do {\
+    mln_span_stack_free();\
+    mln_span_root = NULL;\
     mln_func_entry_callback_set(mln_span_entry);\
     mln_func_exit_callback_set(mln_span_exit);\
     mln_span_registered_thread = GetCurrentThreadId();\
-    mln_span_root = NULL;\
-    __mln_span_stack_top = __mln_span_stack_bottom = NULL;\
-    mln_span_entry(__FILE__, __FUNCTION__, __LINE__);\
+    mln_span_entry(NULL, __FILE__, __FUNCTION__, __LINE__);\
 } while (0)
 #else
 #define mln_span_start() ({\
+    mln_span_stack_free();\
+    mln_span_root = NULL;\
     mln_func_entry_callback_set(mln_span_entry);\
     mln_func_exit_callback_set(mln_span_exit);\
     mln_span_registered_thread = pthread_self();\
-    __mln_span_stack_top = __mln_span_stack_bottom = NULL;\
-    mln_span_root = NULL;\
-    mln_span_entry(__FILE__, __FUNCTION__, __LINE__);\
+    mln_span_entry(NULL, __FILE__, __FUNCTION__, __LINE__);\
 })
 #endif
 
 #if !defined(MSVC)
 #define mln_span_stop() ({\
-    mln_span_exit(__FILE__, __FUNCTION__, __LINE__, NULL);\
+    mln_span_exit(NULL, __FILE__, __FUNCTION__, __LINE__, NULL);\
     mln_func_entry_callback_set(NULL);\
     mln_func_exit_callback_set(NULL);\
     mln_span_stack_free();\
@@ -81,6 +75,7 @@ extern void mln_span_exit(void *fptr, const char *file, const char *func, int li
 #define mln_span_release() ({\
     mln_span_free(mln_span_root);\
     mln_span_root = NULL;\
+    mln_span_pool_free();\
 })
 
 #define mln_span_move() ({\
@@ -96,7 +91,7 @@ extern void mln_span_exit(void *fptr, const char *file, const char *func, int li
 })
 #else
 #define mln_span_stop() do {\
-    mln_span_exit(__FILE__, __FUNCTION__, __LINE__, NULL);\
+    mln_span_exit(NULL, __FILE__, __FUNCTION__, __LINE__, NULL);\
     mln_func_entry_callback_set(NULL);\
     mln_func_exit_callback_set(NULL);\
     mln_span_stack_free();\
@@ -112,4 +107,3 @@ extern mln_u64_t mln_span_time_cost(mln_span_t *s);
 
 extern void mln_span_dump(mln_span_dump_cb_t cb, void *data);
 #endif
-

--- a/src/mln_span.c
+++ b/src/mln_span.c
@@ -7,8 +7,6 @@
 #include <assert.h>
 #include "mln_span.h"
 
-mln_span_stack_node_t *__mln_span_stack_top = NULL;
-mln_span_stack_node_t *__mln_span_stack_bottom = NULL;
 mln_span_t *mln_span_root = NULL;
 #if defined(MSVC)
 DWORD mln_span_registered_thread;
@@ -16,108 +14,162 @@ DWORD mln_span_registered_thread;
 pthread_t mln_span_registered_thread;
 #endif
 
-static inline void mln_span_chain_add(mln_span_t **head, mln_span_t **tail, mln_span_t *node)
-{
-    if (head == NULL || tail == NULL || node == NULL) return;
-    node->prev = node->next = NULL;
-    if (*head == NULL) {
-        *head = *tail = node;
-        return;
-    }
-    (*tail)->next = node;
-    node->prev = (*tail);
-    *tail = node;
-}
-
-static inline void mln_span_chain_del(mln_span_t **head, mln_span_t **tail, mln_span_t *node)
-{
-    if (head == NULL || tail == NULL || node == NULL) return;
-    if (*head == node) {
-        if (*tail == node) {
-            *head = *tail = NULL;
-        } else {
-            *head = node->next;
-            (*head)->prev = NULL;
-        }
-    } else {
-        if (*tail == node) {
-            *tail = node->prev;
-            (*tail)->next = NULL;
-        } else {
-            node->prev->next = node->next;
-            node->next->prev = node->prev;
-        }
-    }
-    node->prev = node->next = NULL;
-}
-
 /*
- * callstack
+ * Chunked call-stack: each chunk holds a fixed-size array of span pointers.
+ * Chunks are linked via ->next (pointing to the chunk below).
+ * Exhausted chunks are moved to a free list for reuse, avoiding
+ * any per-push/per-pop malloc/free and any realloc+copy overhead.
  */
-static void mln_span_stack_node_free(mln_span_stack_node_t *s)
+#define MLN_SPAN_STACK_CHUNK_SIZE 512
+
+typedef struct mln_span_stack_chunk_s {
+    mln_span_t                       *entries[MLN_SPAN_STACK_CHUNK_SIZE];
+    struct mln_span_stack_chunk_s    *next;
+} mln_span_stack_chunk_t;
+
+static mln_span_stack_chunk_t *__stack_cur = NULL;
+static int __stack_pos = -1;
+static mln_span_stack_chunk_t *__stack_free_chunks = NULL;
+
+static inline mln_span_t *mln_span_stack_peek(void)
 {
-    if (s == NULL) return;
-    free(s);
+    if (__stack_cur == NULL || __stack_pos < 0) return NULL;
+    return __stack_cur->entries[__stack_pos];
 }
 
-static mln_span_t *mln_span_stack_top(void)
+static inline int mln_span_stack_push(mln_span_t *span)
 {
-    return __mln_span_stack_top == NULL? NULL: __mln_span_stack_top->span;
-}
-
-static int mln_span_stack_push(mln_span_t *span)
-{
-    mln_span_stack_node_t *s;
-
-    if ((s = (mln_span_stack_node_t *)malloc(sizeof(mln_span_stack_node_t))) == NULL) {
-        return -1;
+    if (__stack_cur == NULL || __stack_pos + 1 >= MLN_SPAN_STACK_CHUNK_SIZE) {
+        mln_span_stack_chunk_t *chunk = __stack_free_chunks;
+        if (chunk != NULL) {
+            __stack_free_chunks = chunk->next;
+        } else {
+            chunk = (mln_span_stack_chunk_t *)malloc(sizeof(mln_span_stack_chunk_t));
+            if (chunk == NULL) return -1;
+        }
+        chunk->next = __stack_cur;
+        __stack_cur = chunk;
+        __stack_pos = 0;
+        chunk->entries[0] = span;
+        return 0;
     }
-    s->span = span;
-    s->next = __mln_span_stack_top;
-    if (__mln_span_stack_top == NULL) __mln_span_stack_bottom = s;
-    __mln_span_stack_top = s;
+    __stack_cur->entries[++__stack_pos] = span;
     return 0;
 }
 
-static mln_span_t *mln_span_stack_pop(void)
+static inline mln_span_t *mln_span_stack_pop(void)
 {
-    mln_span_stack_node_t *s;
-    if ((s = __mln_span_stack_top) == NULL) return NULL;
-    mln_span_t *span = s->span;
-    if (__mln_span_stack_bottom == __mln_span_stack_top)
-        __mln_span_stack_top = __mln_span_stack_bottom = NULL;
-    else
-        __mln_span_stack_top = s->next;
-    mln_span_stack_node_free(s);
+    mln_span_t *span;
+
+    if (__stack_cur == NULL || __stack_pos < 0) return NULL;
+
+    span = __stack_cur->entries[__stack_pos--];
+    if (__stack_pos < 0 && __stack_cur->next != NULL) {
+        mln_span_stack_chunk_t *old = __stack_cur;
+        __stack_cur = old->next;
+        old->next = __stack_free_chunks;
+        __stack_free_chunks = old;
+        __stack_pos = MLN_SPAN_STACK_CHUNK_SIZE - 1;
+    }
     return span;
 }
 
 void mln_span_stack_free(void)
 {
-    mln_span_stack_node_t *s;
-
-    while ((s = __mln_span_stack_top) != NULL) {
-        if (__mln_span_stack_bottom == __mln_span_stack_top)
-            __mln_span_stack_top = __mln_span_stack_bottom = NULL;
-        else
-            __mln_span_stack_top = s->next;
-        mln_span_stack_node_free(s);
+    while (__stack_cur != NULL) {
+        mln_span_stack_chunk_t *prev = __stack_cur->next;
+        __stack_cur->next = __stack_free_chunks;
+        __stack_free_chunks = __stack_cur;
+        __stack_cur = prev;
     }
+    __stack_pos = -1;
 }
 
 /*
- * subspan
+ * Chunked span pool: allocates mln_span_t objects in bulk (one malloc
+ * per MLN_SPAN_POOL_CHUNK_SIZE spans).  Freed spans go onto a free-list
+ * for O(1) reuse; the chunks themselves are freed only when
+ * mln_span_pool_free() is called.
  */
+#define MLN_SPAN_POOL_CHUNK_SIZE 512
+
+typedef struct mln_span_pool_chunk_s {
+    struct mln_span_pool_chunk_s *next;
+    mln_span_t                    spans[MLN_SPAN_POOL_CHUNK_SIZE];
+} mln_span_pool_chunk_t;
+
+static mln_span_pool_chunk_t *__pool_head = NULL;
+static int __pool_used = MLN_SPAN_POOL_CHUNK_SIZE;
+static mln_span_t *__pool_free_list = NULL;
+
+static inline mln_span_t *mln_span_pool_alloc(void)
+{
+    if (__pool_free_list != NULL) {
+        mln_span_t *s = __pool_free_list;
+        __pool_free_list = s->next;
+        return s;
+    }
+    if (__pool_used >= MLN_SPAN_POOL_CHUNK_SIZE) {
+        mln_span_pool_chunk_t *chunk;
+        chunk = (mln_span_pool_chunk_t *)malloc(sizeof(mln_span_pool_chunk_t));
+        if (chunk == NULL) return NULL;
+        chunk->next = __pool_head;
+        __pool_head = chunk;
+        __pool_used = 0;
+    }
+    return &__pool_head->spans[__pool_used++];
+}
+
+static inline void mln_span_pool_recycle(mln_span_t *s)
+{
+    s->next = __pool_free_list;
+    __pool_free_list = s;
+}
+
+MLN_FUNC_VOID(, void, mln_span_pool_free, (void), (), {
+    mln_span_pool_chunk_t *pchunk;
+    mln_span_stack_chunk_t *schunk;
+
+    while ((pchunk = __pool_head) != NULL) {
+        __pool_head = pchunk->next;
+        free(pchunk);
+    }
+    __pool_used = MLN_SPAN_POOL_CHUNK_SIZE;
+    __pool_free_list = NULL;
+
+    while (__stack_cur != NULL) {
+        schunk = __stack_cur;
+        __stack_cur = schunk->next;
+        free(schunk);
+    }
+    while ((schunk = __stack_free_chunks) != NULL) {
+        __stack_free_chunks = schunk->next;
+        free(schunk);
+    }
+    __stack_pos = -1;
+})
 
 /*
- * span
+ * Subspan chain helper
+ */
+static inline void mln_span_chain_add(mln_span_t **head, mln_span_t **tail, mln_span_t *node)
+{
+    node->prev = *tail;
+    node->next = NULL;
+    if (*tail != NULL)
+        (*tail)->next = node;
+    else
+        *head = node;
+    *tail = node;
+}
+
+/*
+ * Span creation / destruction
  */
 mln_span_t *mln_span_new(mln_span_t *parent, const char *file, const char *func, int line)
 {
-    mln_span_t *s;
-
-    if ((s = (mln_span_t *)malloc(sizeof(mln_span_t))) == NULL)
-        return NULL;
+    mln_span_t *s = mln_span_pool_alloc();
+    if (s == NULL) return NULL;
 
     memset(&s->begin, 0, sizeof(struct timeval));
     memset(&s->end, 0, sizeof(struct timeval));
@@ -136,15 +188,32 @@ mln_span_t *mln_span_new(mln_span_t *parent, const char *file, const char *func,
 
 void mln_span_free(mln_span_t *s)
 {
+    mln_span_t *cur, *child, *parent;
+    int is_root;
+
     if (s == NULL) return;
-    mln_span_t *sub;
-    while ((sub = s->subspans_head) != NULL) {
-        mln_span_chain_del(&s->subspans_head, &s->subspans_tail, sub);
-        mln_span_free(sub);
+
+    /* Iterative post-order traversal using the tree's own pointers */
+    cur = s;
+    for (;;) {
+        if (cur->subspans_head != NULL) {
+            child = cur->subspans_head;
+            cur->subspans_head = child->next;
+            if (child->next != NULL) child->next->prev = NULL;
+            cur = child;
+        } else {
+            parent = cur->parent;
+            is_root = (cur == s);
+            mln_span_pool_recycle(cur);
+            if (is_root) break;
+            cur = parent;
+        }
     }
-    free(s);
 }
 
+/*
+ * Entry / exit callbacks
+ */
 int mln_span_entry(void *fptr, const char *file, const char *func, int line, ...)
 {
     mln_span_t *span;
@@ -154,7 +223,7 @@ int mln_span_entry(void *fptr, const char *file, const char *func, int line, ...
 #else
     if (!pthread_equal(mln_span_registered_thread, pthread_self())) return 0;
 #endif
-    if ((span = mln_span_new(mln_span_stack_top(), file, func, line)) == NULL) {
+    if ((span = mln_span_new(mln_span_stack_peek(), file, func, line)) == NULL) {
         assert(0);
         return 0;
     }
@@ -175,7 +244,7 @@ void mln_span_exit(void *fptr, const char *file, const char *func, int line, voi
 #else
     if (!pthread_equal(mln_span_registered_thread, pthread_self())) return;
 #endif
-    mln_span_t *span = (mln_span_t *)mln_span_stack_pop();
+    mln_span_t *span = mln_span_stack_pop();
     if (span == NULL) {
         assert(0);
         return;
@@ -183,6 +252,9 @@ void mln_span_exit(void *fptr, const char *file, const char *func, int line, voi
     gettimeofday(&span->end, NULL);
 }
 
+/*
+ * Dump
+ */
 static void __mln_span_dump(mln_span_t *s, mln_span_dump_cb_t cb, void *data, int level)
 {
     if (s == NULL || cb == NULL) return;
@@ -205,6 +277,7 @@ void mln_span_release(void)
 {
     mln_span_free(mln_span_root);
     mln_span_root = NULL;
+    mln_span_pool_free();
 }
 
 mln_span_t *mln_span_move(void)
@@ -219,4 +292,3 @@ mln_u64_t mln_span_time_cost(mln_span_t *s)
     return (mln_u64_t)(s->end.tv_sec * 1000000 + s->end.tv_usec) - (s->begin.tv_sec * 1000000 + s->begin.tv_usec);
 }
 #endif
-

--- a/t/span.c
+++ b/t/span.c
@@ -1,0 +1,468 @@
+#define MLN_FUNC_FLAG
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <time.h>
+#include "mln_types.h"
+#include "mln_span.h"
+#include "mln_func.h"
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define RUN_TEST(fn) do { \
+    tests_run++; \
+    fn(); \
+    tests_passed++; \
+    printf("  PASS: %s\n", #fn); \
+} while (0)
+
+/* ---- traced helper functions (use MLN_FUNC) ---- */
+
+MLN_FUNC(static, int, traced_add, (int a, int b), (a, b), {
+    return a + b;
+})
+
+MLN_FUNC(static, int, traced_mul, (int a, int b), (a, b), {
+    return traced_add(a, b) * 2;
+})
+
+MLN_FUNC(static, int, traced_compute, (int a, int b), (a, b), {
+    return traced_mul(a, b) + traced_add(a, b);
+})
+
+MLN_FUNC(static, int, traced_recurse, (int n), (n), {
+    if (n <= 0) return 0;
+    return traced_recurse(n - 1) + 1;
+})
+
+MLN_FUNC(static, int, traced_noop, (int x), (x), {
+    return x;
+})
+
+/* ---- dump helpers ---- */
+
+static int dump_count;
+static int dump_max_level;
+
+static void count_dump_cb(mln_span_t *s, int level, void *data)
+{
+    (void)s; (void)data;
+    dump_count++;
+    if (level > dump_max_level) dump_max_level = level;
+}
+
+static void verify_dump_cb(mln_span_t *s, int level, void *data)
+{
+    (void)data;
+    assert(s != NULL);
+    assert(mln_span_file(s) != NULL);
+    assert(mln_span_func(s) != NULL);
+    assert(level >= 0);
+    dump_count++;
+}
+
+/* ---- tests ---- */
+
+static void test_new_free(void)
+{
+    mln_span_t *s = mln_span_new(NULL, "test.c", "test_func", 42);
+    assert(s != NULL);
+    assert(strcmp(mln_span_file(s), "test.c") == 0);
+    assert(strcmp(mln_span_func(s), "test_func") == 0);
+    assert(mln_span_line(s) == 42);
+    assert(s->subspans_head == NULL);
+    assert(s->subspans_tail == NULL);
+    assert(s->parent == NULL);
+    assert(s->prev == NULL);
+    assert(s->next == NULL);
+    mln_span_free(s);
+    mln_span_pool_free();
+}
+
+static void test_new_with_parent(void)
+{
+    mln_span_t *parent = mln_span_new(NULL, "p.c", "parent_fn", 10);
+    assert(parent != NULL);
+
+    mln_span_t *child1 = mln_span_new(parent, "c.c", "child1_fn", 20);
+    assert(child1 != NULL);
+    assert(child1->parent == parent);
+    assert(parent->subspans_head == child1);
+    assert(parent->subspans_tail == child1);
+
+    mln_span_t *child2 = mln_span_new(parent, "c.c", "child2_fn", 30);
+    assert(child2 != NULL);
+    assert(parent->subspans_head == child1);
+    assert(parent->subspans_tail == child2);
+    assert(child1->next == child2);
+    assert(child2->prev == child1);
+
+    mln_span_t *grandchild = mln_span_new(child1, "g.c", "gc_fn", 40);
+    assert(grandchild != NULL);
+    assert(grandchild->parent == child1);
+    assert(child1->subspans_head == grandchild);
+
+    mln_span_free(parent);
+    mln_span_pool_free();
+}
+
+static void test_start_stop_basic(void)
+{
+    mln_span_start();
+    traced_add(1, 2);
+    mln_span_stop();
+
+    assert(mln_span_root != NULL);
+    assert(mln_span_file(mln_span_root) != NULL);
+    assert(mln_span_func(mln_span_root) != NULL);
+    assert(mln_span_line(mln_span_root) > 0);
+    mln_span_release();
+}
+
+static void test_dump_count(void)
+{
+    mln_span_start();
+    traced_compute(3, 4);
+    mln_span_stop();
+
+    dump_count = 0;
+    dump_max_level = 0;
+    mln_span_dump(count_dump_cb, NULL);
+    /*
+     * root(start) -> traced_compute -> { traced_mul -> traced_add, traced_add }
+     * = 1 root + 1 compute + 1 mul + 2 add = 5
+     */
+    assert(dump_count == 5);
+    assert(dump_max_level >= 2);
+
+    mln_span_release();
+}
+
+static void test_dump_verify(void)
+{
+    mln_span_start();
+    traced_mul(10, 20);
+    mln_span_stop();
+
+    dump_count = 0;
+    mln_span_dump(verify_dump_cb, NULL);
+    assert(dump_count > 0);
+
+    mln_span_release();
+}
+
+static void test_dump_null(void)
+{
+    /* NULL callback should not crash */
+    mln_span_dump(NULL, NULL);
+
+    /* NULL root should not crash */
+    assert(mln_span_root == NULL);
+    mln_span_dump(count_dump_cb, NULL);
+}
+
+static void test_move(void)
+{
+    mln_span_start();
+    traced_add(1, 2);
+    mln_span_stop();
+
+    assert(mln_span_root != NULL);
+    mln_span_t *moved = mln_span_move();
+    assert(moved != NULL);
+    assert(mln_span_root == NULL);
+
+    /* verify moved span is still valid */
+    dump_count = 0;
+    mln_span_root = moved;
+    mln_span_dump(count_dump_cb, NULL);
+    assert(dump_count > 0);
+    mln_span_root = NULL;
+
+    mln_span_free(moved);
+    mln_span_pool_free();
+}
+
+static void test_time_cost(void)
+{
+    mln_span_start();
+    traced_add(1, 2);
+    mln_span_stop();
+
+    assert(mln_span_root != NULL);
+    mln_u64_t cost = mln_span_time_cost(mln_span_root);
+    /* cost should be non-negative (>= 0) in microseconds */
+    (void)cost;
+
+    /* check sub-spans also have valid times */
+    if (mln_span_root->subspans_head != NULL) {
+        mln_u64_t sub_cost = mln_span_time_cost(mln_span_root->subspans_head);
+        (void)sub_cost;
+    }
+
+    mln_span_release();
+}
+
+static void test_file_func_line(void)
+{
+    mln_span_start();
+    traced_add(5, 6);
+    mln_span_stop();
+
+    assert(mln_span_root != NULL);
+    /* root span's file/func/line come from mln_span_start macro location */
+    assert(mln_span_file(mln_span_root) != NULL);
+    assert(mln_span_func(mln_span_root) != NULL);
+    assert(mln_span_line(mln_span_root) > 0);
+
+    /* first child should be traced_add */
+    mln_span_t *child = mln_span_root->subspans_head;
+    assert(child != NULL);
+    assert(strstr(mln_span_file(child), "span.c") != NULL);
+
+    mln_span_release();
+}
+
+static void test_deep_nesting(void)
+{
+    mln_span_start();
+    int result = traced_recurse(200);
+    assert(result == 200);
+    mln_span_stop();
+
+    dump_count = 0;
+    dump_max_level = 0;
+    mln_span_dump(count_dump_cb, NULL);
+    /* root + 201 recursive calls = 202 */
+    assert(dump_count == 202);
+    assert(dump_max_level >= 200);
+
+    mln_span_release();
+}
+
+static void test_many_siblings(void)
+{
+    mln_span_start();
+    int i;
+    for (i = 0; i < 2000; ++i) {
+        traced_add(i, i + 1);
+    }
+    mln_span_stop();
+
+    dump_count = 0;
+    mln_span_dump(count_dump_cb, NULL);
+    /* root + 2000 add calls = 2001 */
+    assert(dump_count == 2001);
+
+    mln_span_release();
+}
+
+static void test_mixed_tree(void)
+{
+    mln_span_start();
+    int i;
+    for (i = 0; i < 100; ++i) {
+        traced_compute(i, i + 1);
+    }
+    mln_span_stop();
+
+    dump_count = 0;
+    mln_span_dump(count_dump_cb, NULL);
+    /* root + 100 * (compute + mul + add_in_mul + add_in_compute) = 1 + 400 = 401 */
+    assert(dump_count == 401);
+
+    mln_span_release();
+}
+
+static void test_repeated_cycles(void)
+{
+    int cycle;
+    for (cycle = 0; cycle < 200; ++cycle) {
+        mln_span_start();
+        traced_compute(cycle, cycle + 1);
+        mln_span_stop();
+
+        assert(mln_span_root != NULL);
+        mln_span_release();
+    }
+}
+
+static void test_free_null(void)
+{
+    mln_span_free(NULL);
+    /* should not crash */
+}
+
+static void test_free_single(void)
+{
+    mln_span_t *s = mln_span_new(NULL, "f.c", "fn", 1);
+    assert(s != NULL);
+    mln_span_free(s);
+    mln_span_pool_free();
+}
+
+static void test_free_deep_tree(void)
+{
+    /* Build a deep tree manually and verify iterative free handles it */
+    mln_span_t *root = mln_span_new(NULL, "d.c", "root", 1);
+    assert(root != NULL);
+    mln_span_t *cur = root;
+    int i;
+    for (i = 0; i < 5000; ++i) {
+        mln_span_t *child = mln_span_new(cur, "d.c", "child", i);
+        assert(child != NULL);
+        cur = child;
+    }
+    /* This would stack-overflow with recursive free; iterative handles it */
+    mln_span_free(root);
+    mln_span_pool_free();
+}
+
+static void test_free_wide_tree(void)
+{
+    mln_span_t *root = mln_span_new(NULL, "w.c", "root", 1);
+    assert(root != NULL);
+    int i;
+    for (i = 0; i < 5000; ++i) {
+        mln_span_t *child = mln_span_new(root, "w.c", "child", i);
+        assert(child != NULL);
+    }
+    mln_span_free(root);
+    mln_span_pool_free();
+}
+
+static void test_pool_reuse(void)
+{
+    /* Verify the pool recycles memory across cycles */
+    int cycle;
+    for (cycle = 0; cycle < 50; ++cycle) {
+        mln_span_start();
+        int i;
+        for (i = 0; i < 100; ++i) {
+            traced_add(i, i + 1);
+        }
+        mln_span_stop();
+
+        /* free spans (recycles to pool) */
+        mln_span_free(mln_span_root);
+        mln_span_root = NULL;
+        /* do NOT call mln_span_pool_free: spans stay in free list */
+    }
+    /* final cleanup */
+    mln_span_pool_free();
+}
+
+static void test_move_then_free(void)
+{
+    mln_span_start();
+    traced_compute(1, 2);
+    traced_compute(3, 4);
+    mln_span_stop();
+
+    mln_span_t *moved = mln_span_move();
+    assert(moved != NULL);
+    assert(mln_span_root == NULL);
+
+    dump_count = 0;
+    mln_span_root = moved;
+    mln_span_dump(count_dump_cb, NULL);
+    mln_span_root = NULL;
+    assert(dump_count > 0);
+
+    mln_span_free(moved);
+    mln_span_pool_free();
+}
+
+static void test_benchmark(void)
+{
+    const int N = 1000000;
+    clock_t start, end;
+    double elapsed;
+    int i;
+
+    mln_span_start();
+
+    start = clock();
+    for (i = 0; i < N; ++i) {
+        traced_noop(i);
+    }
+    end = clock();
+
+    mln_span_stop();
+
+    elapsed = (double)(end - start) / CLOCKS_PER_SEC;
+    if (elapsed > 0) {
+        printf("    Benchmark: %d traced calls in %.4f sec (%.0f calls/sec)\n",
+               N, elapsed, (double)N / elapsed);
+    } else {
+        printf("    Benchmark: %d traced calls in < 1ms\n", N);
+    }
+
+    mln_span_release();
+}
+
+static void test_stability(void)
+{
+    const int ROUNDS = 2000;
+    int round;
+
+    for (round = 0; round < ROUNDS; ++round) {
+        mln_span_start();
+
+        int count = (round % 50) + 1;
+        int i;
+        for (i = 0; i < count; ++i) {
+            traced_compute(i, i + 1);
+        }
+
+        mln_span_stop();
+
+        if (round % 7 == 0) {
+            dump_count = 0;
+            mln_span_dump(count_dump_cb, NULL);
+            assert(dump_count > 0);
+        }
+
+        if (round % 3 == 0) {
+            mln_span_t *moved = mln_span_move();
+            assert(moved != NULL);
+            mln_span_free(moved);
+            mln_span_pool_free();
+        } else {
+            mln_span_release();
+        }
+    }
+}
+
+int main(void)
+{
+    printf("Span tests:\n");
+
+    RUN_TEST(test_new_free);
+    RUN_TEST(test_new_with_parent);
+    RUN_TEST(test_start_stop_basic);
+    RUN_TEST(test_dump_count);
+    RUN_TEST(test_dump_verify);
+    RUN_TEST(test_dump_null);
+    RUN_TEST(test_move);
+    RUN_TEST(test_time_cost);
+    RUN_TEST(test_file_func_line);
+    RUN_TEST(test_deep_nesting);
+    RUN_TEST(test_many_siblings);
+    RUN_TEST(test_mixed_tree);
+    RUN_TEST(test_repeated_cycles);
+    RUN_TEST(test_free_null);
+    RUN_TEST(test_free_single);
+    RUN_TEST(test_free_deep_tree);
+    RUN_TEST(test_free_wide_tree);
+    RUN_TEST(test_pool_reuse);
+    RUN_TEST(test_move_then_free);
+    RUN_TEST(test_benchmark);
+    RUN_TEST(test_stability);
+
+    printf("\nAll %d/%d tests passed.\n", tests_passed, tests_run);
+    return 0;
+}


### PR DESCRIPTION
Replace per-call malloc/free with chunked bulk allocator (512 spans per chunk) and chunked array stack (512 entries per chunk). Freed spans are recycled via free list for O(1) reuse. Also convert recursive mln_span_free to iterative post-order traversal and fix undefined behavior in macro argument counts.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
[https://github.com/Water-Melon/Melon/blob/master/CONTRIBUTING.md#contributing](https://github.com/Water-Melon/Melon/blob/master/CONTRIBUTING.md#contributing)
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
