### PR TITLE
feat(connection): add TLS support to mln_tcp_conn_t

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Valgrind
-      run: sudo apt-get update && sudo apt-get install valgrind -y
+    - name: Install Valgrind and OpenSSL dev
+      run: sudo apt-get update && sudo apt-get install valgrind libssl-dev -y
 
     - uses: actions/checkout@v3
     - name: Build and Test
       run: |
-        sudo chmod -R 777 /usr/local && export MLN_TEST_RUNNER=valgrind && ./configure && make && make install && make test && export LD_LIBRARY_PATH=./lib:$LD_LIBRARY_PATH && make run
+        sudo chmod -R 777 /usr/local && export MLN_TEST_RUNNER=valgrind && ./configure --enable-tls && make && make install && make test && export LD_LIBRARY_PATH=./lib:$LD_LIBRARY_PATH && make run

--- a/configure
+++ b/configure
@@ -359,7 +359,7 @@ detect_operating_system_tls_support() {
             tls_ldflag="$tls_lib -lssl -lcrypto"
             output="TLS\t\t\t[OpenSSL]"
         else
-            echo "openssl headers/libs not found; --enable-tls ignored (set OPENSSL_INCLUDE and OPENSSL_LIB to override)"
+            echo "OpenSSL >= 1.1.0 required; --enable-tls ignored (TLS_method() not found -- set OPENSSL_INCLUDE and OPENSSL_LIB to override)"
         fi
         rm -f tls_test tls_test.c
     fi

--- a/configure
+++ b/configure
@@ -45,6 +45,11 @@ select_files='all'
 # disabled macros
 disabled_macros=""
 
+# tls
+tls_enabled=0
+tls_flag=""
+tls_ldflag=""
+
 # llvm
 llvm_flag=""
 
@@ -149,6 +154,7 @@ get_params() {
             echo -e "\t--func"
             echo -e "\t--c99"
             echo -e "\t--enable-lto"
+            echo -e "\t--enable-tls"
             exit 0
         fi
         param_prefix=`echo $param|cut -d '=' -f 1`
@@ -172,6 +178,8 @@ get_params() {
         elif [ $param_prefix == "--enable-lto" ]; then
             lto_flag='-flto'
             lto_link_flag='-flto'
+        elif [ $param_prefix == "--enable-tls" ]; then
+            tls_enabled=1
         elif [ $param_prefix == "--select" ]; then
             select_files=$param_suffix
         elif [ $param_prefix == "--disable-macro" ]; then
@@ -320,6 +328,44 @@ detect_operating_system_mmap_support() {
     echo -e $output
 }
 
+detect_operating_system_tls_support() {
+    output="TLS\t\t\t[disabled]"
+    tls_flag=""
+    tls_ldflag=""
+    if [ "$tls_enabled" -eq 1 ]; then
+        tls_inc=""
+        tls_lib=""
+        # Common Homebrew / system layouts that ship a pkg-config-less openssl
+        for p in \
+            /opt/homebrew/opt/openssl@3 \
+            /usr/local/opt/openssl@3 \
+            /opt/homebrew/opt/openssl \
+            /usr/local/opt/openssl \
+            /opt/local
+        do
+            if [ -f "$p/include/openssl/ssl.h" ]; then
+                tls_inc="-I$p/include"
+                tls_lib="-L$p/lib"
+                break
+            fi
+        done
+        # Allow override via env so CI / non-standard layouts can plug in.
+        if [ -n "$OPENSSL_INCLUDE" ]; then tls_inc="-I$OPENSSL_INCLUDE"; fi
+        if [ -n "$OPENSSL_LIB" ];     then tls_lib="-L$OPENSSL_LIB";     fi
+        echo -e "#include <openssl/ssl.h>\nint main(void){SSL_CTX_new(TLS_method());return 0;}" > tls_test.c
+        $cc $tls_inc -o tls_test tls_test.c $tls_lib -lssl -lcrypto 2>/dev/null
+        if [ "$?" = "0" ]; then
+            tls_flag="-DMLN_TLS $tls_inc"
+            tls_ldflag="$tls_lib -lssl -lcrypto"
+            output="TLS\t\t\t[OpenSSL]"
+        else
+            echo "openssl headers/libs not found; --enable-tls ignored (set OPENSSL_INCLUDE and OPENSSL_LIB to override)"
+        fi
+        rm -f tls_test tls_test.c
+    fi
+    echo -e $output
+}
+
 detect_operating_system_constructor_support() {
     output="constructor\t\t[NOT support]"
     if [[ ! "${disabled_macros[@]}" =~ "constructor_flag" ]]; then
@@ -344,6 +390,7 @@ detect_operating_system_support() {
         detect_operating_system_unix98_support
         detect_operating_system_mmap_support
         detect_operating_system_constructor_support
+        detect_operating_system_tls_support
     fi
 }
 
@@ -427,7 +474,7 @@ generate_Makefile() {
     if [ $wasm -eq 1 ]; then
         echo -e "FLAGS\t\t= -Iinclude -c $debug $olevel $llvm_flag -s -mmutable-globals -mnontrapping-fptoint -msign-ext -Wemcc -DMLN_ROOT=\\\"$realpath\\\" -DMLN_NULL=\\\"$nullpath\\\" -DMLN_LANG_LIB=\\\"$melang_script_path\\\" -DMLN_LANG_DYLIB=\\\"$melang_dylib_path\\\" $CFLAGS" >> Makefile
     else
-        echo -e "FLAGS\t\t= -Iinclude -c -Wall $debug -Werror $mingw_cflags $olevel $lto_flag -fPIC -DMLN_ROOT=\\\"$realpath\\\" -DMLN_NULL=\\\"$nullpath\\\" -DMLN_LANG_LIB=\\\"$melang_script_path\\\" -DMLN_LANG_DYLIB=\\\"$melang_dylib_path\\\" $event_flag $sendfile_flag $writev_flag $unix98_flag $mmap_flag $func_flag $c99_flag $constructor_flag $msys2_flag $CFLAGS" >> Makefile
+        echo -e "FLAGS\t\t= -Iinclude -c -Wall $debug -Werror $mingw_cflags $olevel $lto_flag -fPIC -DMLN_ROOT=\\\"$realpath\\\" -DMLN_NULL=\\\"$nullpath\\\" -DMLN_LANG_LIB=\\\"$melang_script_path\\\" -DMLN_LANG_DYLIB=\\\"$melang_dylib_path\\\" $event_flag $sendfile_flag $writev_flag $unix98_flag $mmap_flag $func_flag $c99_flag $constructor_flag $msys2_flag $tls_flag $CFLAGS" >> Makefile
     fi
     if ! case $sysname in MINGW*) false;; esac; then
         if [ $wasm -eq 0 ]; then
@@ -474,11 +521,11 @@ generate_Makefile() {
     if [ $wasm -eq 0 ]; then
         echo "\$(MELONSO) : \$(OBJS)" >> Makefile
         if [ $sysname = 'Linux' ]; then
-            echo -e "\t\$(CC) -o lib/\$(MELONSO) \$(OBJS) $debug $lto_link_flag -Wall -lpthread -Llib/ -ldl -shared -fPIC $LDFLAGS" >> Makefile
+            echo -e "\t\$(CC) -o lib/\$(MELONSO) \$(OBJS) $debug $lto_link_flag -Wall -lpthread -Llib/ -ldl $tls_ldflag -shared -fPIC $LDFLAGS" >> Makefile
         elif ! case $sysname in MINGW*) false;; esac; then
-            echo -e "\t\$(CC) -o lib/\$(MELONSO) \$(OBJS) $debug $lto_link_flag -Wall -lpthread -lWs2_32 -Llib/ -shared -fPIC $LDFLAGS" >> Makefile
+            echo -e "\t\$(CC) -o lib/\$(MELONSO) \$(OBJS) $debug $lto_link_flag -Wall -lpthread -lWs2_32 -Llib/ $tls_ldflag -shared -fPIC $LDFLAGS" >> Makefile
         else
-            echo -e "\t\$(CC) -o lib/\$(MELONSO) \$(OBJS) $debug $lto_link_flag -Wall -lpthread -Llib/ -lc -shared -fPIC $LDFLAGS" >> Makefile
+            echo -e "\t\$(CC) -o lib/\$(MELONSO) \$(OBJS) $debug $lto_link_flag -Wall -lpthread -Llib/ -lc $tls_ldflag -shared -fPIC $LDFLAGS" >> Makefile
         fi
     fi
     echo "install:" >> Makefile
@@ -513,7 +560,7 @@ generate_Makefile() {
             done
             echo "" >> Makefile
 
-            echo -e "\t\$(CC) -o \$@ $fname $debug -Iinclude -Llib -lmelon" >> Makefile
+            echo -e "\t\$(CC) -o \$@ $fname $debug -Iinclude $tls_flag -Llib -lmelon $tls_ldflag" >> Makefile
         fi
     done
     echo -e "BINS = \\" >> Makefile

--- a/docs/book/cn/tcp_io.md
+++ b/docs/book/cn/tcp_io.md
@@ -463,9 +463,9 @@ typedef struct mln_tcp_tls_conf_s {
     mln_string_t   *key_file;
     mln_string_t   *ca_file;
     mln_string_t   *ciphers;
+    mln_u32_t       versions;    /* M_TLS_V* 标志位掩码 */
     mln_u32_t       role:1;      /* M_TLS_SERVER / M_TLS_CLIENT */
     mln_u32_t       verify:1;
-    mln_u32_t       versions:6;
 } mln_tcp_tls_conf_t;
 ```
 

--- a/docs/book/cn/tcp_io.md
+++ b/docs/book/cn/tcp_io.md
@@ -473,28 +473,6 @@ typedef struct mln_tcp_tls_conf_s {
 
 
 
-#### mln_tcp_tls_global_init
-
-```c
-int mln_tcp_tls_global_init(void);
-```
-
-描述：OpenSSL全局初始化。**要求OpenSSL 1.1.0或更高版本**（不支持1.0.x）。OpenSSL 1.1.0起该调用实际是空操作（该版本引入了自动初始化机制）；保留接口是为了让调用方可无条件调用。可重复调用。
-
-返回值：成功返回`0`
-
-
-
-#### mln_tcp_tls_global_destroy
-
-```c
-void mln_tcp_tls_global_destroy(void);
-```
-
-描述：与`mln_tcp_tls_global_init`对应的清理函数。
-
-
-
 #### mln_tcp_tls_conf_new
 
 ```c

--- a/docs/book/cn/tcp_io.md
+++ b/docs/book/cn/tcp_io.md
@@ -437,7 +437,7 @@ mln_tcp_conn_pool_get(pconn)
 ./configure --enable-tls
 ```
 
-`configure`会自动探测常见OpenSSL安装位置（含macOS Homebrew的`/opt/homebrew/opt/openssl@3`等），也可通过`OPENSSL_INCLUDE`和`OPENSSL_LIB`环境变量手动指定。未找到时会跳过TLS并给出提示，不会让整个构建失败。
+`configure`会自动探测常见OpenSSL安装位置（含macOS Homebrew的`/opt/homebrew/opt/openssl@3`等），也可通过`OPENSSL_INCLUDE`和`OPENSSL_LIB`环境变量手动指定。**要求OpenSSL 1.1.0或更高版本；不支持1.0.x**。未找到合适的OpenSSL时会跳过TLS并给出提示，不会让整个构建失败。
 
 未启用`--enable-tls`时，下述接口与字段全部不存在，二进制与历史版本字节一致。
 
@@ -479,7 +479,7 @@ typedef struct mln_tcp_tls_conf_s {
 int mln_tcp_tls_global_init(void);
 ```
 
-描述：OpenSSL全局初始化。对OpenSSL 1.1及以上版本是一个空操作；保留接口是为了让调用方在更老的版本上也能写出可移植的代码。可重复调用。
+描述：OpenSSL全局初始化。**要求OpenSSL 1.1.0或更高版本**（不支持1.0.x）。OpenSSL 1.1.0起该调用实际是空操作（该版本引入了自动初始化机制）；保留接口是为了让调用方可无条件调用。可重复调用。
 
 返回值：成功返回`0`
 

--- a/docs/book/cn/tcp_io.md
+++ b/docs/book/cn/tcp_io.md
@@ -425,6 +425,232 @@ mln_tcp_conn_pool_get(pconn)
 
 
 
+### TLS支持
+
+`mln_connection`内建对TLS（HTTPS）的支持，由OpenSSL作为后端实现。整套TLS逻辑被集成在`mln_tcp_conn_t`内部，**任何上层代码（包括`mln_http`）都无需感知或修改**——只要将连接通过`mln_tcp_conn_tls_init`初始化，后续的`mln_tcp_conn_send`、`mln_tcp_conn_recv`即会自动完成加密与解密。
+
+未启用TLS的连接（通过`mln_tcp_conn_init`初始化）走原有路径，性能与历史版本一致：开启`MLN_TLS`编译宏后，明文路径仅在入口处多出一次空指针判断与条件跳转。
+
+#### 启用编译
+
+```bash
+./configure --enable-tls
+```
+
+`configure`会自动探测常见OpenSSL安装位置（含macOS Homebrew的`/opt/homebrew/opt/openssl@3`等），也可通过`OPENSSL_INCLUDE`和`OPENSSL_LIB`环境变量手动指定。未找到时会跳过TLS并给出提示，不会让整个构建失败。
+
+未启用`--enable-tls`时，下述接口与字段全部不存在，二进制与历史版本字节一致。
+
+#### 相关常量
+
+```c
+/* 角色 */
+#define M_TLS_SERVER   0
+#define M_TLS_CLIENT   1
+
+/* 协议版本掩码 */
+#define M_TLS_V1_2     0x4
+#define M_TLS_V1_3     0x8
+#define M_TLS_VDEFAULT (M_TLS_V1_2 | M_TLS_V1_3)
+```
+
+#### 相关结构
+
+```c
+typedef struct mln_tcp_tls_conf_s {
+    SSL_CTX        *ctx;
+    mln_string_t   *cert_file;
+    mln_string_t   *key_file;
+    mln_string_t   *ca_file;
+    mln_string_t   *ciphers;
+    mln_u32_t       role:1;      /* M_TLS_SERVER / M_TLS_CLIENT */
+    mln_u32_t       verify:1;
+    mln_u32_t       versions:6;
+} mln_tcp_tls_conf_t;
+```
+
+配置结构可在多个连接之间共享，由调用方负责管理其生命周期。`cert_file`/`key_file`/`ca_file`/`ciphers` 字段由 `mln_tcp_tls_conf_new` 深拷贝持有，调用方传入的 `mln_string_t` 在 `conf_new` 返回后即可释放。
+
+
+
+#### mln_tcp_tls_global_init
+
+```c
+int mln_tcp_tls_global_init(void);
+```
+
+描述：OpenSSL全局初始化。对OpenSSL 1.1及以上版本是一个空操作；保留接口是为了让调用方在更老的版本上也能写出可移植的代码。可重复调用。
+
+返回值：成功返回`0`
+
+
+
+#### mln_tcp_tls_global_destroy
+
+```c
+void mln_tcp_tls_global_destroy(void);
+```
+
+描述：与`mln_tcp_tls_global_init`对应的清理函数。
+
+
+
+#### mln_tcp_tls_conf_new
+
+```c
+mln_tcp_tls_conf_t *
+mln_tcp_tls_conf_new(mln_u32_t role,
+                     mln_string_t *cert_file,
+                     mln_string_t *key_file,
+                     mln_string_t *ca_file,
+                     mln_string_t *ciphers,
+                     mln_u32_t versions,
+                     mln_u32_t verify);
+```
+
+描述：构造一份TLS配置，封装一个`SSL_CTX`和证书等信息。各参数：
+
+- `role`：`M_TLS_SERVER`时必须提供`cert_file`和`key_file`；`M_TLS_CLIENT`时两者可为`NULL`。
+- `ca_file`：PEM格式的受信CA证书集合。开启客户端证书校验时使用。
+- `ciphers`：TLSv1.2 cipher list；`NULL`使用OpenSSL默认。
+- `versions`：`M_TLS_V1_2 | M_TLS_V1_3`的位掩码，`0`等同于`M_TLS_VDEFAULT`。
+- `verify`：非零表示要求验证对端证书。
+
+返回值：成功返回结构指针，失败返回`NULL`
+
+
+
+#### mln_tcp_tls_conf_free
+
+```c
+void mln_tcp_tls_conf_free(mln_tcp_tls_conf_t *conf);
+```
+
+描述：释放配置及其内部`SSL_CTX`。
+
+
+
+#### mln_tcp_conn_tls_init
+
+```c
+int mln_tcp_conn_tls_init(mln_tcp_conn_t *tc, int sockfd, mln_tcp_tls_conf_t *conf);
+```
+
+描述：与`mln_tcp_conn_init`平行的TLS初始化函数。`tc`完成初始化后就是一条TLS连接，后续`mln_tcp_conn_send/recv`自动完成加解密。`conf`必须在`tc`销毁前持续有效（不会被`tc`接管或释放）。
+
+返回值：成功返回`0`，失败返回`-1`
+
+
+
+#### mln_tcp_conn_tls_handshake
+
+```c
+int mln_tcp_conn_tls_handshake(mln_tcp_conn_t *tc);
+```
+
+描述：显式驱动TLS握手。**非必须**——首次调用`mln_tcp_conn_send`或`mln_tcp_conn_recv`时会自动触发。提供该函数主要是为了在事件循环里把"握手完成"和"开始读写"分作两个独立的回调处理。
+
+返回值：
+
+- `M_C_FINISH`握手完成
+- `M_C_NOTYET`仍需更多I/O，调用方可参考`mln_tcp_conn_tls_want_read`/`mln_tcp_conn_tls_want_write`重新注册事件
+- `M_C_ERROR`握手失败
+- `M_C_CLOSED`对端在握手过程中关闭
+
+
+
+#### mln_tcp_conn_tls_shutdown
+
+```c
+int mln_tcp_conn_tls_shutdown(mln_tcp_conn_t *tc);
+```
+
+描述：发送TLS `close_notify`，进行优雅关闭。非阻塞模式下可能返回`M_C_NOTYET`，需待socket可写后重试。
+
+返回值：`M_C_FINISH`/`M_C_NOTYET`/`M_C_ERROR`
+
+
+
+#### mln_tcp_conn_tls_set_sni
+
+```c
+int mln_tcp_conn_tls_set_sni(mln_tcp_conn_t *tc, mln_string_t *hostname);
+```
+
+描述：客户端使用，设置握手时发送的SNI主机名。必须在握手开始之前调用。
+
+返回值：成功返回`0`，失败返回`-1`
+
+
+
+#### mln_tcp_conn_tls_set_verify_host
+
+```c
+int mln_tcp_conn_tls_set_verify_host(mln_tcp_conn_t *tc, mln_string_t *hostname);
+```
+
+描述：客户端使用，对服务端证书启用RFC 6125主机名校验。需配合`mln_tcp_tls_conf_new`时`verify=1`使用。
+
+返回值：成功返回`0`，失败返回`-1`
+
+
+
+#### 状态查询宏
+
+```c
+mln_tcp_conn_tls_enabled(tc)    /* 当前连接是否为TLS */
+mln_tcp_conn_tls_done(tc)       /* 握手是否完成 */
+mln_tcp_conn_tls_want_read(tc)  /* 上一次I/O是否在等可读事件 */
+mln_tcp_conn_tls_want_write(tc) /* 上一次I/O是否在等可写事件 */
+```
+
+非阻塞模式下，`mln_tcp_conn_send/recv/tls_handshake`返回`M_C_NOTYET`时，调用方应根据`want_read`/`want_write`重新设置`mln_event_fd_set`关注的事件——TLS存在"想读其实是想写"（重协商）的场景，必须如实反映到事件层。
+
+
+
+#### 行为说明
+
+- 队列内容仅为明文：`snd_*`、`rcv_*`、`sent_*`三条队列中始终只存放明文`mln_chain_t`；密文只在内部栈缓冲与OpenSSL的内存BIO中流动，不会与明文混在同一队列里。
+- `sent_*`语义严格：一条chain只有在其对应的密文已经被`writev/send`真正写到socket之后，才会被移入`sent_*`；网络写阻塞时该chain仍然停留在`snd_*`头部，下次调用继续从断点处续传。
+- `in_file`类型的buf：会被`mln_tcp_conn_send`内部按16 KiB为单位先`read`到栈缓冲再交给`SSL_write`。注意TLS路径下零拷贝`sendfile`是不可用的。
+- `mln_tcp_conn_recv`在TLS连接上的`flag`必须是`M_C_TYPE_MEMORY`；`M_C_TYPE_FILE`本期不支持。
+- `mln_tcp_conn_destroy`会自动`SSL_free`，无需调用方额外处理；但不会释放共享的`mln_tcp_tls_conf_t`。
+
+
+
+#### 简单示例
+
+服务端：
+
+```c
+mln_string_t cert = mln_string("/etc/melon/server.pem");
+mln_string_t key  = mln_string("/etc/melon/server.key");
+mln_tcp_tls_conf_t *conf = mln_tcp_tls_conf_new(
+    M_TLS_SERVER, &cert, &key, NULL, NULL, M_TLS_VDEFAULT, 0);
+
+int fd = accept(listen_fd, NULL, NULL);
+mln_tcp_conn_t conn;
+mln_tcp_conn_tls_init(&conn, fd, conf);
+/* 之后 mln_tcp_conn_send / mln_tcp_conn_recv 即自动走TLS */
+```
+
+客户端：
+
+```c
+mln_tcp_tls_conf_t *conf = mln_tcp_tls_conf_new(
+    M_TLS_CLIENT, NULL, NULL, &ca_bundle, NULL, M_TLS_VDEFAULT, 1);
+
+int fd = ...; /* connect 之后 */
+mln_tcp_conn_t conn;
+mln_tcp_conn_tls_init(&conn, fd, conf);
+
+mln_string_t host = mln_string("example.com");
+mln_tcp_conn_tls_set_sni(&conn, &host);
+mln_tcp_conn_tls_set_verify_host(&conn, &host);
+```
+
+
+
 ### 示例
 
 本篇示例碍于篇幅，仅给出部分片段展示如何使用。

--- a/docs/book/en/tcp_io.md
+++ b/docs/book/en/tcp_io.md
@@ -423,6 +423,286 @@ Return value: `mln_alloc_t` structure pointer
 
 
 
+### TLS support
+
+`mln_connection` has built-in TLS (HTTPS) support, backed by OpenSSL.
+All TLS logic is folded into `mln_tcp_conn_t`, so **no upper-layer code
+needs to change** — `mln_http` and any other consumer keeps using
+`mln_tcp_conn_send` / `mln_tcp_conn_recv`. A connection initialized with
+`mln_tcp_conn_tls_init` is automatically a TLS connection; subsequent
+sends and receives transparently encrypt and decrypt.
+
+Connections initialized through the plain `mln_tcp_conn_init` path are
+byte-for-byte unchanged on the hot path. When the `MLN_TLS` macro is
+enabled, the plain path only pays the cost of one extra load and one
+conditional branch at the very top of `mln_tcp_conn_send/recv`.
+
+#### Enable at build time
+
+```bash
+./configure --enable-tls
+```
+
+`configure` probes common OpenSSL install locations (including macOS
+Homebrew layouts such as `/opt/homebrew/opt/openssl@3`), and accepts
+`OPENSSL_INCLUDE` and `OPENSSL_LIB` env vars for overrides. If OpenSSL
+cannot be found the flag is reported as ignored and the rest of the
+build proceeds normally.
+
+When `--enable-tls` is **not** passed, none of the APIs and fields
+below exist, and the resulting binary is identical to historical
+builds.
+
+#### Constants
+
+```c
+/* Role */
+#define M_TLS_SERVER   0
+#define M_TLS_CLIENT   1
+
+/* Protocol version bitmask */
+#define M_TLS_V1_2     0x4
+#define M_TLS_V1_3     0x8
+#define M_TLS_VDEFAULT (M_TLS_V1_2 | M_TLS_V1_3)
+```
+
+#### Structures
+
+```c
+typedef struct mln_tcp_tls_conf_s {
+    SSL_CTX        *ctx;
+    mln_string_t   *cert_file;
+    mln_string_t   *key_file;
+    mln_string_t   *ca_file;
+    mln_string_t   *ciphers;
+    mln_u32_t       role:1;      /* M_TLS_SERVER / M_TLS_CLIENT */
+    mln_u32_t       verify:1;
+    mln_u32_t       versions:6;
+} mln_tcp_tls_conf_t;
+```
+
+A configuration object is intended to be shared across many
+connections; the caller owns its lifetime.  The `cert_file`,
+`key_file`, `ca_file` and `ciphers` fields are deep-copied by
+`mln_tcp_tls_conf_new`, so the caller may free the `mln_string_t`
+arguments immediately after construction.
+
+
+
+#### mln_tcp_tls_global_init
+
+```c
+int mln_tcp_tls_global_init(void);
+```
+
+Description: One-time OpenSSL global initialization. On OpenSSL 1.1.0
+and later this is a no-op; the function exists so that callers can
+write portable code targeting both old and new OpenSSL versions. Safe
+to call repeatedly.
+
+Return value: `0` on success.
+
+
+
+#### mln_tcp_tls_global_destroy
+
+```c
+void mln_tcp_tls_global_destroy(void);
+```
+
+Description: Companion teardown for `mln_tcp_tls_global_init`.
+
+
+
+#### mln_tcp_tls_conf_new
+
+```c
+mln_tcp_tls_conf_t *
+mln_tcp_tls_conf_new(mln_u32_t role,
+                     mln_string_t *cert_file,
+                     mln_string_t *key_file,
+                     mln_string_t *ca_file,
+                     mln_string_t *ciphers,
+                     mln_u32_t versions,
+                     mln_u32_t verify);
+```
+
+Description: Build a TLS configuration that wraps an `SSL_CTX` and
+certificate material. Parameters:
+
+- `role`: `M_TLS_SERVER` requires both `cert_file` and `key_file`;
+  `M_TLS_CLIENT` may pass `NULL` for both.
+- `ca_file`: PEM bundle of trusted CAs; enables peer verification when
+  `verify` is non-zero.
+- `ciphers`: TLSv1.2 cipher list; `NULL` for OpenSSL's default.
+- `versions`: bitmask of `M_TLS_V1_2 | M_TLS_V1_3`; `0` is treated as
+  `M_TLS_VDEFAULT`.
+- `verify`: non-zero requires peer certificate verification.
+
+Return value: structure pointer on success, `NULL` on failure.
+
+
+
+#### mln_tcp_tls_conf_free
+
+```c
+void mln_tcp_tls_conf_free(mln_tcp_tls_conf_t *conf);
+```
+
+Description: Free the configuration along with its `SSL_CTX`.
+
+
+
+#### mln_tcp_conn_tls_init
+
+```c
+int mln_tcp_conn_tls_init(mln_tcp_conn_t *tc, int sockfd, mln_tcp_tls_conf_t *conf);
+```
+
+Description: The TLS counterpart of `mln_tcp_conn_init`. After this
+returns successfully `tc` represents a TLS connection; subsequent
+`mln_tcp_conn_send` / `mln_tcp_conn_recv` calls handle encryption and
+decryption automatically. `conf` must outlive `tc`; it is not
+consumed.
+
+Return value: `0` on success, `-1` on failure.
+
+
+
+#### mln_tcp_conn_tls_handshake
+
+```c
+int mln_tcp_conn_tls_handshake(mln_tcp_conn_t *tc);
+```
+
+Description: Drive the TLS handshake explicitly. **Optional** — the
+first call to `mln_tcp_conn_send` or `mln_tcp_conn_recv` will do it
+automatically. The standalone entry point is convenient when an event
+loop wants to handle "handshake done" and "ready for I/O" as two
+separate callbacks.
+
+Return value:
+
+- `M_C_FINISH` handshake finished
+- `M_C_NOTYET` more I/O needed; the caller should consult
+  `mln_tcp_conn_tls_want_read` / `mln_tcp_conn_tls_want_write` and
+  re-register the appropriate event
+- `M_C_ERROR` handshake failed
+- `M_C_CLOSED` peer hung up mid-handshake
+
+
+
+#### mln_tcp_conn_tls_shutdown
+
+```c
+int mln_tcp_conn_tls_shutdown(mln_tcp_conn_t *tc);
+```
+
+Description: Send TLS `close_notify` for a graceful shutdown.
+Non-blocking callers may receive `M_C_NOTYET` and need to retry once
+the socket is writable.
+
+Return value: `M_C_FINISH` / `M_C_NOTYET` / `M_C_ERROR`.
+
+
+
+#### mln_tcp_conn_tls_set_sni
+
+```c
+int mln_tcp_conn_tls_set_sni(mln_tcp_conn_t *tc, mln_string_t *hostname);
+```
+
+Description: Client side. Set the SNI hostname sent during the
+handshake. Must be called before the handshake starts.
+
+Return value: `0` on success, `-1` on failure.
+
+
+
+#### mln_tcp_conn_tls_set_verify_host
+
+```c
+int mln_tcp_conn_tls_set_verify_host(mln_tcp_conn_t *tc, mln_string_t *hostname);
+```
+
+Description: Client side. Enable RFC 6125 hostname verification of the
+server certificate. Use together with `verify=1` in
+`mln_tcp_tls_conf_new`.
+
+Return value: `0` on success, `-1` on failure.
+
+
+
+#### Status macros
+
+```c
+mln_tcp_conn_tls_enabled(tc)    /* is this a TLS connection? */
+mln_tcp_conn_tls_done(tc)       /* has the handshake completed? */
+mln_tcp_conn_tls_want_read(tc)  /* did the last I/O ask for a readable event? */
+mln_tcp_conn_tls_want_write(tc) /* did the last I/O ask for a writable event? */
+```
+
+In non-blocking mode, when `mln_tcp_conn_send`, `mln_tcp_conn_recv` or
+`mln_tcp_conn_tls_handshake` returns `M_C_NOTYET`, the caller must
+re-register fd interest using `want_read` / `want_write`. TLS has a
+legitimate "want read while doing a write" condition (renegotiation),
+and the event loop has to honour that faithfully.
+
+
+
+#### Behaviour notes
+
+- Queues hold plaintext only: `snd_*`, `rcv_*` and `sent_*` always
+  contain plaintext `mln_chain_t`. Ciphertext only ever lives on the
+  stack and inside OpenSSL's memory BIOs, so the receive queue can
+  never become a mixture of decrypted and yet-to-be-decrypted bytes.
+- Strict `sent_*` semantics: a chain only moves to `sent_*` after its
+  matching ciphertext has actually been written to the socket. If the
+  socket fills up, the chain stays at the head of `snd_*` and the next
+  call resumes from where it left off.
+- `in_file` bufs: read into a 16 KiB stack buffer in 16 KiB chunks
+  before being fed to `SSL_write`. Zero-copy `sendfile` is not
+  available on the TLS path.
+- `mln_tcp_conn_recv` on a TLS connection accepts only
+  `M_C_TYPE_MEMORY`; `M_C_TYPE_FILE` is not supported in this release.
+- `mln_tcp_conn_destroy` calls `SSL_free` for you; it does not free
+  the shared `mln_tcp_tls_conf_t`.
+
+
+
+#### Quick examples
+
+Server:
+
+```c
+mln_string_t cert = mln_string("/etc/melon/server.pem");
+mln_string_t key  = mln_string("/etc/melon/server.key");
+mln_tcp_tls_conf_t *conf = mln_tcp_tls_conf_new(
+    M_TLS_SERVER, &cert, &key, NULL, NULL, M_TLS_VDEFAULT, 0);
+
+int fd = accept(listen_fd, NULL, NULL);
+mln_tcp_conn_t conn;
+mln_tcp_conn_tls_init(&conn, fd, conf);
+/* Now mln_tcp_conn_send / mln_tcp_conn_recv transparently use TLS. */
+```
+
+Client:
+
+```c
+mln_tcp_tls_conf_t *conf = mln_tcp_tls_conf_new(
+    M_TLS_CLIENT, NULL, NULL, &ca_bundle, NULL, M_TLS_VDEFAULT, 1);
+
+int fd = ...; /* after connect() */
+mln_tcp_conn_t conn;
+mln_tcp_conn_tls_init(&conn, fd, conf);
+
+mln_string_t host = mln_string("example.com");
+mln_tcp_conn_tls_set_sni(&conn, &host);
+mln_tcp_conn_tls_set_verify_host(&conn, &host);
+```
+
+
+
 ### Example
 
 Due to the space of this example, only some fragments are given to show how to use it.

--- a/docs/book/en/tcp_io.md
+++ b/docs/book/en/tcp_io.md
@@ -475,9 +475,9 @@ typedef struct mln_tcp_tls_conf_s {
     mln_string_t   *key_file;
     mln_string_t   *ca_file;
     mln_string_t   *ciphers;
+    mln_u32_t       versions;    /* bitmask of M_TLS_V* constants */
     mln_u32_t       role:1;      /* M_TLS_SERVER / M_TLS_CLIENT */
     mln_u32_t       verify:1;
-    mln_u32_t       versions:6;
 } mln_tcp_tls_conf_t;
 ```
 

--- a/docs/book/en/tcp_io.md
+++ b/docs/book/en/tcp_io.md
@@ -490,32 +490,6 @@ arguments immediately after construction.
 
 
 
-#### mln_tcp_tls_global_init
-
-```c
-int mln_tcp_tls_global_init(void);
-```
-
-Description: One-time OpenSSL global initialization. Requires OpenSSL
-**1.1.0 or later** (the minimum supported version). On OpenSSL 1.1.0
-and later this call is effectively a no-op because that release
-introduced automatic initialisation; it exists so callers can invoke it
-unconditionally. Safe to call repeatedly.
-
-Return value: `0` on success.
-
-
-
-#### mln_tcp_tls_global_destroy
-
-```c
-void mln_tcp_tls_global_destroy(void);
-```
-
-Description: Companion teardown for `mln_tcp_tls_global_init`.
-
-
-
 #### mln_tcp_tls_conf_new
 
 ```c

--- a/docs/book/en/tcp_io.md
+++ b/docs/book/en/tcp_io.md
@@ -445,9 +445,10 @@ conditional branch at the very top of `mln_tcp_conn_send/recv`.
 
 `configure` probes common OpenSSL install locations (including macOS
 Homebrew layouts such as `/opt/homebrew/opt/openssl@3`), and accepts
-`OPENSSL_INCLUDE` and `OPENSSL_LIB` env vars for overrides. If OpenSSL
-cannot be found the flag is reported as ignored and the rest of the
-build proceeds normally.
+`OPENSSL_INCLUDE` and `OPENSSL_LIB` env vars for overrides. OpenSSL
+**1.1.0 or later is required**; OpenSSL 1.0.x is not supported. If
+a suitable OpenSSL cannot be found the flag is reported as ignored and
+the rest of the build proceeds normally.
 
 When `--enable-tls` is **not** passed, none of the APIs and fields
 below exist, and the resulting binary is identical to historical
@@ -495,10 +496,11 @@ arguments immediately after construction.
 int mln_tcp_tls_global_init(void);
 ```
 
-Description: One-time OpenSSL global initialization. On OpenSSL 1.1.0
-and later this is a no-op; the function exists so that callers can
-write portable code targeting both old and new OpenSSL versions. Safe
-to call repeatedly.
+Description: One-time OpenSSL global initialization. Requires OpenSSL
+**1.1.0 or later** (the minimum supported version). On OpenSSL 1.1.0
+and later this call is effectively a no-op because that release
+introduced automatic initialisation; it exists so callers can invoke it
+unconditionally. Safe to call repeatedly.
 
 Return value: `0` on success.
 

--- a/include/mln_connection.h
+++ b/include/mln_connection.h
@@ -136,13 +136,6 @@ extern int mln_tcp_conn_send_chain(mln_tcp_conn_t *tc, mln_chain_t *chain) __NON
  *   M_C_FINISH / M_C_NOTYET / M_C_ERROR / M_C_CLOSED.
  */
 
-/*
- * Process-wide one-time init.  Safe to call multiple times.  On OpenSSL
- * 1.1.0 and later this is a no-op; the call exists so consumers can be
- * written portably across versions.
- */
-extern int  mln_tcp_tls_global_init(void);
-extern void mln_tcp_tls_global_destroy(void);
 
 /*
  * Build a config.  Returns NULL on failure (bad files, OpenSSL error...).

--- a/include/mln_connection.h
+++ b/include/mln_connection.h
@@ -14,6 +14,10 @@
 #include "mln_types.h"
 #include "mln_chain.h"
 #include "mln_alloc.h"
+#if defined(MLN_TLS)
+#include "mln_string.h"
+#include <openssl/ssl.h>
+#endif
 
 
 /*buffer type*/
@@ -34,6 +38,32 @@
 #define M_C_TYPE_MEMORY 0x1
 #define M_C_TYPE_FILE   0x2
 
+#if defined(MLN_TLS)
+/*TLS role*/
+#define M_TLS_SERVER   0
+#define M_TLS_CLIENT   1
+
+/*TLS protocol version mask*/
+#define M_TLS_V1_2     0x4
+#define M_TLS_V1_3     0x8
+#define M_TLS_VDEFAULT (M_TLS_V1_2 | M_TLS_V1_3)
+
+typedef struct mln_tcp_tls_conf_s {
+    SSL_CTX        *ctx;
+    mln_string_t   *cert_file;
+    mln_string_t   *key_file;
+    mln_string_t   *ca_file;
+    mln_string_t   *ciphers;
+    /* Full-width versions field instead of a narrow bitfield: lets
+     * future protocol additions (M_TLS_V1_4 etc.) fit without an
+     * ABI-breaking widen, and stops mln_tcp_tls_conf_new from
+     * silently truncating unknown bits. */
+    mln_u32_t       versions;
+    mln_u32_t       role:1;
+    mln_u32_t       verify:1;
+} mln_tcp_tls_conf_t;
+#endif
+
 typedef struct {
     mln_alloc_t *pool;
     mln_chain_t *rcv_head;
@@ -44,6 +74,24 @@ typedef struct {
     mln_chain_t *sent_tail;
     int          sockfd;
     mln_u32_t    nonblock:1;
+#if defined(MLN_TLS)
+    /* TLS state: all zero/NULL on a plain TCP connection. */
+    SSL                 *ssl;
+    mln_tcp_tls_conf_t  *tls_conf;  /* not owned */
+    /* Pending ciphertext that was read out of wbio but the socket
+     * could not yet swallow.  Must be drained in-order before any
+     * further BIO_read, otherwise the TLS byte stream gets reordered
+     * and the peer drops the connection on MAC failure.  Allocated
+     * lazily from `pool` on the first call to mln_tcp_conn_tls_flush_wbio.
+     */
+    mln_u8ptr_t          tls_pending;
+    mln_size_t           tls_pending_off;
+    mln_size_t           tls_pending_len;
+    mln_u32_t            tls_done:1;
+    mln_u32_t            tls_want_r:1;
+    mln_u32_t            tls_want_w:1;
+    mln_u32_t            tls_shut:1;
+#endif
 } mln_tcp_conn_t;
 
 
@@ -71,6 +119,89 @@ extern int mln_tcp_conn_send(mln_tcp_conn_t *tc) __NONNULL1(1);
 extern int mln_tcp_conn_recv(mln_tcp_conn_t *tc, mln_u32_t flag) __NONNULL1(1);
 extern void mln_tcp_conn_move_sent(mln_tcp_conn_t *tc) __NONNULL1(1);
 extern int mln_tcp_conn_send_chain(mln_tcp_conn_t *tc, mln_chain_t *chain) __NONNULL2(1,2);
+
+#if defined(MLN_TLS)
+/*
+ * TLS support
+ *
+ * A TLS connection is just an mln_tcp_conn_t initialized through
+ * mln_tcp_conn_tls_init() instead of mln_tcp_conn_init(); after that
+ * the regular mln_tcp_conn_send/recv functions transparently encrypt
+ * and decrypt.
+ *
+ * Configuration objects (mln_tcp_tls_conf_t) wrap an SSL_CTX and may
+ * be shared across many connections.
+ *
+ * Return value conventions match mln_tcp_conn_send/recv:
+ *   M_C_FINISH / M_C_NOTYET / M_C_ERROR / M_C_CLOSED.
+ */
+
+/*
+ * Process-wide one-time init.  Safe to call multiple times.  On OpenSSL
+ * 1.1.0 and later this is a no-op; the call exists so consumers can be
+ * written portably across versions.
+ */
+extern int  mln_tcp_tls_global_init(void);
+extern void mln_tcp_tls_global_destroy(void);
+
+/*
+ * Build a config.  Returns NULL on failure (bad files, OpenSSL error...).
+ *
+ *   role:        M_TLS_SERVER requires non-NULL cert_file and key_file.
+ *                M_TLS_CLIENT may pass NULL for both.
+ *   ca_file:     PEM bundle of trusted CAs (client side); enables peer
+ *                verification when 'verify' is non-zero.
+ *   ciphers:     TLSv1.2 cipher list, NULL for OpenSSL default.
+ *   versions:    bitmask of M_TLS_V1_2 / M_TLS_V1_3; 0 means default.
+ *   verify:      non-zero to require peer certificate verification.
+ */
+extern mln_tcp_tls_conf_t *
+mln_tcp_tls_conf_new(mln_u32_t role,
+                     mln_string_t *cert_file,
+                     mln_string_t *key_file,
+                     mln_string_t *ca_file,
+                     mln_string_t *ciphers,
+                     mln_u32_t versions,
+                     mln_u32_t verify);
+extern void mln_tcp_tls_conf_free(mln_tcp_tls_conf_t *conf);
+
+/*
+ * Initialize a TCP connection that speaks TLS, parallel to
+ * mln_tcp_conn_init().  conf must outlive tc; it is not consumed.
+ * Returns 0 on success, -1 on failure (errno set when meaningful).
+ */
+extern int
+mln_tcp_conn_tls_init(mln_tcp_conn_t *tc, int sockfd, mln_tcp_tls_conf_t *conf)
+    __NONNULL1(1);
+
+/*
+ * Drive the TLS handshake explicitly.  Optional: the first send/recv
+ * call will trigger it automatically.  Returns M_C_FINISH when done,
+ * M_C_NOTYET when more I/O is needed (check tls_want_r/tls_want_w),
+ * M_C_ERROR on failure, M_C_CLOSED if the peer hung up mid-handshake.
+ */
+extern int mln_tcp_conn_tls_handshake(mln_tcp_conn_t *tc) __NONNULL1(1);
+
+/*
+ * Send TLS close_notify.  Non-blocking callers may receive M_C_NOTYET
+ * and need to retry once the socket is writable.
+ */
+extern int mln_tcp_conn_tls_shutdown(mln_tcp_conn_t *tc) __NONNULL1(1);
+
+/* Client-side: set SNI hostname.  Must be called before handshake. */
+extern int mln_tcp_conn_tls_set_sni(mln_tcp_conn_t *tc, mln_string_t *hostname)
+    __NONNULL2(1,2);
+
+/* Client-side: enable hostname verification (RFC 6125). */
+extern int mln_tcp_conn_tls_set_verify_host(mln_tcp_conn_t *tc, mln_string_t *hostname)
+    __NONNULL2(1,2);
+
+#define mln_tcp_conn_tls_enabled(tc)    ((tc)->ssl != NULL)
+#define mln_tcp_conn_tls_done(tc)       ((tc)->tls_done)
+#define mln_tcp_conn_tls_want_read(tc)  ((tc)->tls_want_r)
+#define mln_tcp_conn_tls_want_write(tc) ((tc)->tls_want_w)
+
+#endif /* MLN_TLS */
 
 #endif
 

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -1038,6 +1038,12 @@ static void mln_tcp_tls_apply_versions(SSL_CTX *ctx, mln_u32_t versions)
 #ifdef TLS1_3_VERSION
         if (min_v == 0) min_v = TLS1_3_VERSION;
         max_v = TLS1_3_VERSION;
+#else
+        /* TLS 1.3 requested but this OpenSSL build doesn't support it.
+         * Fall back to TLS 1.2 so we don't silently negotiate older
+         * versions: treat M_TLS_V1_3-only as "at least TLS 1.2". */
+        if (min_v == 0) min_v = TLS1_2_VERSION;
+        max_v = TLS1_2_VERSION;
 #endif
     } else {
         max_v = TLS1_2_VERSION;

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -27,6 +27,15 @@
 #if defined(MLN_SENDFILE)
 #include <sys/sendfile.h>
 #endif
+#if defined(MLN_TLS)
+#if !defined(MSVC)
+#include <pthread.h>
+#endif
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/bio.h>
+#include <openssl/x509v3.h>
+#endif
 
 
 static inline int mln_fd_is_nonblock(int fd);
@@ -45,6 +54,12 @@ static inline int
 mln_tcp_conn_send_chain_memory(mln_tcp_conn_t *tc);
 static inline int
 mln_tcp_conn_send_chain_file(mln_tcp_conn_t *tc);
+#if defined(MLN_TLS)
+static int mln_tcp_conn_send_tls(mln_tcp_conn_t *tc);
+static int mln_tcp_conn_recv_tls(mln_tcp_conn_t *tc);
+static int mln_tcp_conn_tls_flush_wbio(mln_tcp_conn_t *tc);
+static int mln_tcp_conn_tls_drain_socket(mln_tcp_conn_t *tc);
+#endif
 
 
 static inline int mln_fd_is_nonblock(int fd)
@@ -72,6 +87,17 @@ MLN_FUNC(, int, mln_tcp_conn_init, (mln_tcp_conn_t *tc, int sockfd), (tc, sockfd
     tc->sent_head = tc->sent_tail = NULL;
     tc->sockfd = sockfd;
     tc->nonblock = mln_fd_is_nonblock(sockfd);
+#if defined(MLN_TLS)
+    tc->ssl = NULL;
+    tc->tls_conf = NULL;
+    tc->tls_pending = NULL;
+    tc->tls_pending_off = 0;
+    tc->tls_pending_len = 0;
+    tc->tls_done = 0;
+    tc->tls_want_r = 0;
+    tc->tls_want_w = 0;
+    tc->tls_shut = 0;
+#endif
     return 0;
 })
 
@@ -105,6 +131,13 @@ MLN_FUNC(, int, mln_tcp_conn_set_nonblock, (mln_tcp_conn_t *tc, int nb), (tc, nb
 MLN_FUNC_VOID(, void, mln_tcp_conn_destroy, (mln_tcp_conn_t *tc), (tc), {
     if (tc == NULL) return;
 
+#if defined(MLN_TLS)
+    if (tc->ssl != NULL) {
+        /* SSL_free releases the SSL object and any BIO attached to it. */
+        SSL_free(tc->ssl);
+        tc->ssl = NULL;
+    }
+#endif
     mln_chain_pool_release_all(mln_tcp_conn_remove(tc, M_C_SEND));
     mln_chain_pool_release_all(mln_tcp_conn_remove(tc, M_C_RECV));
     mln_chain_pool_release_all(mln_tcp_conn_remove(tc, M_C_SENT));
@@ -246,6 +279,10 @@ MLN_FUNC(, mln_chain_t *, mln_tcp_conn_tail, (mln_tcp_conn_t *tc, int type), (tc
 
 MLN_FUNC(, int, mln_tcp_conn_send, (mln_tcp_conn_t *tc), (tc), {
     int n;
+
+#if defined(MLN_TLS)
+    if (tc->ssl != NULL) return mln_tcp_conn_send_tls(tc);
+#endif
 
     if (tc->snd_head == NULL) return M_C_NOTYET;
 
@@ -758,6 +795,16 @@ MLN_FUNC(, int, mln_tcp_conn_send_chain, (mln_tcp_conn_t *tc, mln_chain_t *chain
 MLN_FUNC(, int, mln_tcp_conn_recv, (mln_tcp_conn_t *tc, mln_u32_t flag), (tc, flag), {
     ASSERT(flag == M_C_TYPE_MEMORY || flag == M_C_TYPE_FILE);
 
+#if defined(MLN_TLS)
+    if (tc->ssl != NULL) {
+        /* TLS records always require an intermediate memory buffer for
+         * decryption; the file-receive path is intentionally unavailable.
+         */
+        ASSERT(flag == M_C_TYPE_MEMORY);
+        return mln_tcp_conn_recv_tls(tc);
+    }
+#endif
+
     int n;
 
     if (tc->nonblock) {
@@ -889,4 +936,773 @@ static inline int mln_tcp_conn_recv_chain_mem(int sockfd, mln_alloc_t *pool, mln
 
     return n;
 }
+
+
+#if defined(MLN_TLS)
+/* ------------------------------------------------------------------ *
+ *                              TLS path                              *
+ *                                                                    *
+ * The plain mln_tcp_conn_send / mln_tcp_conn_recv paths above remain *
+ * unchanged for sockets that were initialized through                *
+ * mln_tcp_conn_init().  A second initializer, mln_tcp_conn_tls_init, *
+ * attaches an SSL handle plus two memory BIOs (rbio / wbio):         *
+ *                                                                    *
+ *     plaintext  -->  SSL_write  -->  wbio  -->  send(sockfd)        *
+ *     recv(sockfd)  -->  rbio  -->  SSL_read  -->  plaintext         *
+ *                                                                    *
+ * The plaintext lands in rcv_* / snd_* as usual; the ciphertext is   *
+ * only ever held by the BIOs (and a 16 KiB on-stack buffer while it  *
+ * is being moved between BIO and the socket).  Because ciphertext is *
+ * never queued into any mln_chain_t, there is no risk of the rcv_*   *
+ * list mixing decrypted bytes with bytes that still have to be       *
+ * decrypted.                                                         *
+ * ------------------------------------------------------------------ */
+
+#define M_TLS_CHUNK 16384
+
+/* One-shot global OpenSSL init, made thread-safe so concurrent first
+ * callers cannot race the legacy (<1.1.0) init path.  On 1.1.0+ the
+ * library initialises itself on first use, so the work inside the
+ * once-block is empty there; the guard is kept for the rare 1.0.x
+ * builds and as a contract anchor.  Same dual pattern as mln_rs.c.
+ *
+ * The published "inited" flag is declared `volatile long` so the
+ * Windows loser-loop sees a fresh value on every iteration, and on
+ * the same architecture InterlockedExchange gives us a full memory
+ * barrier when the winner publishes.  The POSIX path piggy-backs on
+ * pthread_once's happens-before guarantees and ignores the flag's
+ * type. */
+#if !defined(MSVC)
+static pthread_once_t mln_tcp_tls_init_once = PTHREAD_ONCE_INIT;
+#else
+static volatile long mln_tcp_tls_init_once_flag = 0;
+#endif
+static volatile long mln_tcp_tls_global_inited = 0;
+
+static void mln_tcp_tls_global_init_inner(void)
+{
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    SSL_library_init();
+    SSL_load_error_strings();
+    OpenSSL_add_all_algorithms();
+#endif
+#if !defined(MSVC)
+    mln_tcp_tls_global_inited = 1;
+#else
+    /* Publish with a full barrier so the loser loop's volatile load
+     * cannot observe init work reordered after the flag write. */
+    InterlockedExchange(&mln_tcp_tls_global_inited, 1);
+#endif
+}
+
+MLN_FUNC(, int, mln_tcp_tls_global_init, (void), (), {
+#if !defined(MSVC)
+    pthread_once(&mln_tcp_tls_init_once, mln_tcp_tls_global_init_inner);
+#else
+    /* InterlockedCompareExchange winners run the init exactly once;
+     * losers spin until the winner publishes mln_tcp_tls_global_inited.
+     */
+    if (InterlockedCompareExchange(&mln_tcp_tls_init_once_flag, 1, 0) == 0) {
+        mln_tcp_tls_global_init_inner();
+    } else {
+        /* Lose-and-wait path.  Sleep(0) yields the rest of the time
+         * slice to any other ready thread (including the winner), so
+         * we do not peg a core spinning while the init runs. */
+        while (!mln_tcp_tls_global_inited) Sleep(0);
+    }
+#endif
+    return mln_tcp_tls_global_inited ? 0 : -1;
+})
+
+MLN_FUNC_VOID(, void, mln_tcp_tls_global_destroy, (void), (), {
+    /* OpenSSL 1.1+ handles teardown automatically via atexit; pthread_once
+     * cannot be reset, so a deliberate teardown here is intentionally a
+     * no-op.  Kept as a public symbol for API stability across OpenSSL
+     * versions.
+     */
+})
+
+static void mln_tcp_tls_apply_versions(SSL_CTX *ctx, mln_u32_t versions)
+{
+    if (versions == 0) versions = M_TLS_VDEFAULT;
+    /* SSL_CTX_set_{min,max}_proto_version were introduced in OpenSSL
+     * 1.1.0.  TLS1_2_VERSION alone is not a sufficient feature test --
+     * it is defined as far back as 1.0.2 where these setters do not
+     * exist.  On older OpenSSL the version mask is silently ignored;
+     * the SSL_CTX still negotiates whatever the library defaults to.
+     */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    int min_v = 0, max_v = 0;
+    if (versions & M_TLS_V1_2) min_v = TLS1_2_VERSION;
+    if (versions & M_TLS_V1_3) {
+#ifdef TLS1_3_VERSION
+        if (min_v == 0) min_v = TLS1_3_VERSION;
+        max_v = TLS1_3_VERSION;
+#endif
+    } else {
+        max_v = TLS1_2_VERSION;
+    }
+    if (min_v) SSL_CTX_set_min_proto_version(ctx, min_v);
+    if (max_v) SSL_CTX_set_max_proto_version(ctx, max_v);
+#else
+    (void)ctx; (void)versions;
+#endif
+}
+
+MLN_FUNC(, mln_tcp_tls_conf_t *, mln_tcp_tls_conf_new, \
+         (mln_u32_t role, mln_string_t *cert_file, mln_string_t *key_file, \
+          mln_string_t *ca_file, mln_string_t *ciphers, \
+          mln_u32_t versions, mln_u32_t verify), \
+         (role, cert_file, key_file, ca_file, ciphers, versions, verify), \
+{
+    mln_tcp_tls_conf_t *c;
+    const SSL_METHOD   *method;
+
+    if (!mln_tcp_tls_global_inited) (void)mln_tcp_tls_global_init();
+
+    /* Reject anything outside the documented role enum up front -- otherwise
+     * we'd pick the client method for an unknown value but later set the
+     * stored role flag to M_TLS_SERVER, and SSL_set_accept_state() would be
+     * applied to a client-method SSL.  Be strict here. */
+    if (role != M_TLS_SERVER && role != M_TLS_CLIENT) {
+        errno = EINVAL;
+        return NULL;
+    }
+    /* Reject unknown bits in the version mask so we never store a
+     * value that would mislead future readers of conf->versions. */
+    if (versions != 0 && (versions & ~(mln_u32_t)M_TLS_VDEFAULT) != 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    if (role == M_TLS_SERVER) {
+        if (cert_file == NULL || key_file == NULL) {
+            errno = EINVAL;
+            return NULL;
+        }
+        method = TLS_server_method();
+    } else {
+        method = TLS_client_method();
+    }
+
+    c = (mln_tcp_tls_conf_t *)calloc(1, sizeof(*c));
+    if (c == NULL) { errno = ENOMEM; return NULL; }
+
+    c->ctx = SSL_CTX_new(method);
+    if (c->ctx == NULL) goto err;
+    SSL_CTX_set_mode(c->ctx,
+                     SSL_MODE_ENABLE_PARTIAL_WRITE |
+                     SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+    mln_tcp_tls_apply_versions(c->ctx, versions);
+
+    /* No silent truncation: mln_string_t is length-prefixed and may
+     * legitimately exceed any fixed stack buffer; we allocate exactly
+     * what is needed for the trailing NUL OpenSSL APIs require. */
+    if (ciphers != NULL && ciphers->len > 0) {
+        char *buf = (char *)malloc(ciphers->len + 1);
+        if (buf == NULL) { errno = ENOMEM; goto err; }
+        memcpy(buf, ciphers->data, ciphers->len);
+        buf[ciphers->len] = '\0';
+        int ok = SSL_CTX_set_cipher_list(c->ctx, buf);
+        free(buf);
+        if (!ok) goto err;
+    }
+
+    if (cert_file != NULL && cert_file->len > 0) {
+        char *path = (char *)malloc(cert_file->len + 1);
+        if (path == NULL) { errno = ENOMEM; goto err; }
+        memcpy(path, cert_file->data, cert_file->len);
+        path[cert_file->len] = '\0';
+        int ok = (SSL_CTX_use_certificate_chain_file(c->ctx, path) == 1);
+        free(path);
+        if (!ok) goto err;
+    }
+    if (key_file != NULL && key_file->len > 0) {
+        char *path = (char *)malloc(key_file->len + 1);
+        if (path == NULL) { errno = ENOMEM; goto err; }
+        memcpy(path, key_file->data, key_file->len);
+        path[key_file->len] = '\0';
+        int ok = (SSL_CTX_use_PrivateKey_file(c->ctx, path, SSL_FILETYPE_PEM) == 1);
+        free(path);
+        if (!ok) goto err;
+        if (SSL_CTX_check_private_key(c->ctx) != 1) goto err;
+    }
+    if (ca_file != NULL && ca_file->len > 0) {
+        char *path = (char *)malloc(ca_file->len + 1);
+        if (path == NULL) { errno = ENOMEM; goto err; }
+        memcpy(path, ca_file->data, ca_file->len);
+        path[ca_file->len] = '\0';
+        int ok = (SSL_CTX_load_verify_locations(c->ctx, path, NULL) == 1);
+        free(path);
+        if (!ok) goto err;
+    }
+
+    SSL_CTX_set_verify(c->ctx,
+                       verify ? SSL_VERIFY_PEER : SSL_VERIFY_NONE,
+                       NULL);
+
+    /* Deep-copy so the conf is self-contained: callers don't have to
+     * keep their mln_string_t storage alive for the conf's lifetime.
+     * Any dup failure tears the whole conf down. */
+    if (cert_file != NULL && (c->cert_file = mln_string_dup(cert_file)) == NULL) goto err;
+    if (key_file  != NULL && (c->key_file  = mln_string_dup(key_file))  == NULL) goto err;
+    if (ca_file   != NULL && (c->ca_file   = mln_string_dup(ca_file))   == NULL) goto err;
+    if (ciphers   != NULL && (c->ciphers   = mln_string_dup(ciphers))   == NULL) goto err;
+    c->role      = role;  /* role was validated to be M_TLS_SERVER or M_TLS_CLIENT above */
+    c->verify    = verify ? 1 : 0;
+    c->versions  = versions ? versions : M_TLS_VDEFAULT;
+    return c;
+
+err:
+    if (c->cert_file) mln_string_free(c->cert_file);
+    if (c->key_file)  mln_string_free(c->key_file);
+    if (c->ca_file)   mln_string_free(c->ca_file);
+    if (c->ciphers)   mln_string_free(c->ciphers);
+    if (c->ctx)       SSL_CTX_free(c->ctx);
+    free(c);
+    return NULL;
+})
+
+MLN_FUNC_VOID(, void, mln_tcp_tls_conf_free, (mln_tcp_tls_conf_t *conf), (conf), {
+    if (conf == NULL) return;
+    if (conf->cert_file) mln_string_free(conf->cert_file);
+    if (conf->key_file)  mln_string_free(conf->key_file);
+    if (conf->ca_file)   mln_string_free(conf->ca_file);
+    if (conf->ciphers)   mln_string_free(conf->ciphers);
+    if (conf->ctx)       SSL_CTX_free(conf->ctx);
+    free(conf);
+})
+
+MLN_FUNC(, int, mln_tcp_conn_tls_init, \
+         (mln_tcp_conn_t *tc, int sockfd, mln_tcp_tls_conf_t *conf), \
+         (tc, sockfd, conf), \
+{
+    BIO *rbio = NULL, *wbio = NULL;
+
+    /* Defensive: conf is annotated as required, but a partially-initialized
+     * struct (NULL ctx) would otherwise segfault inside SSL_new.
+     */
+    if (conf == NULL || conf->ctx == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (mln_tcp_conn_init(tc, sockfd) < 0) return -1;
+
+    tc->ssl = SSL_new(conf->ctx);
+    if (tc->ssl == NULL) goto err;
+    rbio = BIO_new(BIO_s_mem());
+    wbio = BIO_new(BIO_s_mem());
+    if (rbio == NULL || wbio == NULL) goto err;
+    /* mem BIOs must never return "no data" as a fatal EOF condition;
+     * EOF should look like EAGAIN to OpenSSL while we wait for more
+     * ciphertext to arrive on the socket.
+     */
+    BIO_set_mem_eof_return(rbio, -1);
+    BIO_set_mem_eof_return(wbio, -1);
+    SSL_set_bio(tc->ssl, rbio, wbio);
+    rbio = wbio = NULL; /* now owned by SSL */
+
+    if (conf->role == M_TLS_SERVER) SSL_set_accept_state(tc->ssl);
+    else                            SSL_set_connect_state(tc->ssl);
+
+    tc->tls_conf = conf;
+    return 0;
+
+err:
+    if (rbio) BIO_free(rbio);
+    if (wbio) BIO_free(wbio);
+    if (tc->ssl) { SSL_free(tc->ssl); tc->ssl = NULL; }
+    mln_chain_pool_release_all(mln_tcp_conn_remove(tc, M_C_SEND));
+    mln_chain_pool_release_all(mln_tcp_conn_remove(tc, M_C_RECV));
+    mln_chain_pool_release_all(mln_tcp_conn_remove(tc, M_C_SENT));
+    if (tc->pool) mln_alloc_destroy(tc->pool);
+    tc->pool = NULL;
+    return -1;
+})
+
+MLN_FUNC(, int, mln_tcp_conn_tls_set_sni, \
+         (mln_tcp_conn_t *tc, mln_string_t *hostname), (tc, hostname), \
+{
+    char buf[256];
+    if (tc->ssl == NULL) { errno = EINVAL; return -1; }
+    /* DNS names are bounded by RFC 1035 to 253 octets; anything longer
+     * is either a bug or an attacker-controlled value, and silently
+     * truncating would send an incorrect SNI value.  Reject up front. */
+    if (hostname->len >= sizeof(buf)) { errno = EINVAL; return -1; }
+    memcpy(buf, hostname->data, hostname->len);
+    buf[hostname->len] = '\0';
+    if (SSL_set_tlsext_host_name(tc->ssl, buf) != 1) return -1;
+    return 0;
+})
+
+MLN_FUNC(, int, mln_tcp_conn_tls_set_verify_host, \
+         (mln_tcp_conn_t *tc, mln_string_t *hostname), (tc, hostname), \
+{
+    char buf[256];
+    X509_VERIFY_PARAM *param;
+    if (tc->ssl == NULL) { errno = EINVAL; return -1; }
+    /* Same rationale as SNI: never verify a silently-truncated hostname,
+     * that would let an attacker pass verification against a different
+     * name than the caller intended. */
+    if (hostname->len >= sizeof(buf)) { errno = EINVAL; return -1; }
+    memcpy(buf, hostname->data, hostname->len);
+    buf[hostname->len] = '\0';
+    param = SSL_get0_param(tc->ssl);
+    if (param == NULL) return -1;
+    X509_VERIFY_PARAM_set_hostflags(param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+    if (X509_VERIFY_PARAM_set1_host(param, buf, hostname->len) != 1) return -1;
+    return 0;
+})
+
+/* ------------------------------------------------------------------ *
+ * BIO <-> socket bridges                                             *
+ * ------------------------------------------------------------------ */
+
+/* Drain everything in wbio to the network.  Returns:
+ *   M_C_FINISH  wbio (and pending buffer) fully empty after the call
+ *   M_C_NOTYET  bytes still queued (EAGAIN on socket)
+ *   M_C_ERROR   socket write error other than EAGAIN/EINTR
+ *
+ * Ordering note: BIO_read removes bytes from wbio.  If those bytes only
+ * partially fit on the socket we must NOT BIO_write the tail back -- a
+ * later BIO_read would put fresh ciphertext from SSL_write *before* it
+ * in the stream and corrupt the TLS connection (peer MAC failure).
+ * Instead we stash the unsent tail in tc->tls_pending and drain that
+ * buffer in-order before reading any more from wbio.
+ */
+static int mln_tcp_conn_tls_flush_wbio(mln_tcp_conn_t *tc)
+{
+    int n;
+
+    /* Lazy-allocate the pending buffer from the conn pool the first
+     * time we have to bridge BIO -> socket.  Allocated from the pool
+     * so it is freed together with the conn on destroy.
+     */
+    if (tc->tls_pending == NULL) {
+        tc->tls_pending = (mln_u8ptr_t)mln_alloc_m(tc->pool, M_TLS_CHUNK);
+        if (tc->tls_pending == NULL) { errno = ENOMEM; return M_C_ERROR; }
+        tc->tls_pending_off = 0;
+        tc->tls_pending_len = 0;
+    }
+
+    /* 1) Drain whatever was left from a previous EAGAIN. */
+    while (tc->tls_pending_len > 0) {
+#if defined(MSVC)
+        n = send(tc->sockfd,
+                 (char *)(tc->tls_pending + tc->tls_pending_off),
+                 (int)tc->tls_pending_len, 0);
+#else
+        n = send(tc->sockfd,
+                 tc->tls_pending + tc->tls_pending_off,
+                 tc->tls_pending_len, 0);
+#endif
+        if (n > 0) {
+            tc->tls_pending_off += (mln_size_t)n;
+            tc->tls_pending_len -= (mln_size_t)n;
+            continue;
+        }
+        if (n < 0 && errno == EINTR) continue;
+        if (n < 0 && errno == EAGAIN) {
+            tc->tls_want_w = 1;
+            return M_C_NOTYET;
+        }
+        return M_C_ERROR;
+    }
+
+    /* 2) Now safe to pull more ciphertext from wbio. */
+    for (;;) {
+        int got = BIO_read(SSL_get_wbio(tc->ssl),
+                           tc->tls_pending, M_TLS_CHUNK);
+        if (got <= 0) {
+            /* Empty BIO (eof_return=-1 makes it behave like EAGAIN). */
+            tc->tls_pending_off = 0;
+            tc->tls_pending_len = 0;
+            return M_C_FINISH;
+        }
+        tc->tls_pending_off = 0;
+        tc->tls_pending_len = (mln_size_t)got;
+
+        while (tc->tls_pending_len > 0) {
+#if defined(MSVC)
+            n = send(tc->sockfd,
+                     (char *)(tc->tls_pending + tc->tls_pending_off),
+                     (int)tc->tls_pending_len, 0);
+#else
+            n = send(tc->sockfd,
+                     tc->tls_pending + tc->tls_pending_off,
+                     tc->tls_pending_len, 0);
+#endif
+            if (n > 0) {
+                tc->tls_pending_off += (mln_size_t)n;
+                tc->tls_pending_len -= (mln_size_t)n;
+                continue;
+            }
+            if (n < 0 && errno == EINTR) continue;
+            if (n < 0 && errno == EAGAIN) {
+                tc->tls_want_w = 1;
+                return M_C_NOTYET;
+            }
+            return M_C_ERROR;
+        }
+    }
+}
+
+/* Read available ciphertext off the socket and push into rbio.  Returns:
+ *   M_C_FINISH  one or more reads succeeded (or socket would block)
+ *   M_C_CLOSED  peer closed the connection
+ *   M_C_ERROR   recv error
+ *
+ * For blocking sockets this performs exactly one recv() and then returns
+ * so that SSL_read can make progress; for non-blocking sockets it loops
+ * until EAGAIN.
+ */
+static int mln_tcp_conn_tls_drain_socket(mln_tcp_conn_t *tc)
+{
+    unsigned char buf[M_TLS_CHUNK];
+    int n, got_any = 0;
+
+    for (;;) {
+#if defined(MSVC)
+        n = recv(tc->sockfd, (char *)buf, sizeof buf, 0);
+#else
+        n = recv(tc->sockfd, buf, sizeof buf, 0);
+#endif
+        if (n > 0) {
+            /* A mem-BIO write only fails if it can't allocate.  Treat
+             * a short or failed write as a hard error -- dropping any
+             * ciphertext here would desync the TLS stream and the peer
+             * would close on the next MAC failure. */
+            int w = BIO_write(SSL_get_rbio(tc->ssl), buf, n);
+            if (w != n) { errno = ENOMEM; return M_C_ERROR; }
+            got_any = 1;
+            if (!tc->nonblock) break;
+            continue;
+        }
+        if (n == 0) return got_any ? M_C_FINISH : M_C_CLOSED;
+        if (errno == EINTR) continue;
+        if (errno == EAGAIN) break;
+        return M_C_ERROR;
+    }
+    return M_C_FINISH;
+}
+
+/* ------------------------------------------------------------------ *
+ * Handshake                                                          *
+ * ------------------------------------------------------------------ */
+
+MLN_FUNC(, int, mln_tcp_conn_tls_handshake, (mln_tcp_conn_t *tc), (tc), {
+    int r, err;
+
+    if (tc->ssl == NULL) { errno = EINVAL; return M_C_ERROR; }
+    /* Stale flags from a previous M_C_NOTYET return would otherwise
+     * leak out through the tls_done short-circuit. */
+    tc->tls_want_r = tc->tls_want_w = 0;
+    if (tc->tls_done) return M_C_FINISH;
+
+    for (;;) {
+        tc->tls_want_r = tc->tls_want_w = 0;
+
+        r = SSL_do_handshake(tc->ssl);
+        /* Any handshake message produced (ClientHello, Finished, ...)
+         * lives in wbio now; push it to the wire before reporting state.
+         */
+        {
+            int fr = mln_tcp_conn_tls_flush_wbio(tc);
+            if (fr == M_C_ERROR) return M_C_ERROR;
+            if (fr == M_C_NOTYET) {
+                /* Will retry on the next writable event. */
+                return M_C_NOTYET;
+            }
+        }
+        if (r == 1) {
+            tc->tls_done = 1;
+            return M_C_FINISH;
+        }
+        err = SSL_get_error(tc->ssl, r);
+        if (err == SSL_ERROR_WANT_READ) {
+            int dr = mln_tcp_conn_tls_drain_socket(tc);
+            if (dr == M_C_ERROR || dr == M_C_CLOSED) return dr;
+            if (tc->nonblock) {
+                /* Did the drain bring anything new? */
+                if (BIO_pending(SSL_get_rbio(tc->ssl)) == 0) {
+                    tc->tls_want_r = 1;
+                    return M_C_NOTYET;
+                }
+                continue;
+            }
+            /* Blocking socket: recv() already blocked once; try the
+             * handshake again now that we have bytes.
+             */
+            continue;
+        }
+        if (err == SSL_ERROR_WANT_WRITE) {
+            /* wbio was flushed above; if it stalled we already returned
+             * M_C_NOTYET.  Loop once more to drive forward.
+             */
+            tc->tls_want_w = 1;
+            return M_C_NOTYET;
+        }
+        return M_C_ERROR;
+    }
+})
+
+/* ------------------------------------------------------------------ *
+ * Send                                                               *
+ * ------------------------------------------------------------------ *
+ * Per-chain semantics: a chain is only moved to sent_* once the      *
+ * corresponding ciphertext has actually been transmitted on the      *
+ * socket.  The loop below drains wbio after each successful          *
+ * SSL_write, and any failure of that drain causes us to return       *
+ * M_C_NOTYET with the buf left in snd_*.                              *
+ * ------------------------------------------------------------------ */
+
+static int mln_tcp_conn_tls_write_one_chunk(mln_tcp_conn_t *tc,
+                                            const unsigned char *p,
+                                            size_t n,
+                                            size_t *written)
+{
+    int w;
+    *written = 0;
+    while (*written < n) {
+        w = SSL_write(tc->ssl, p + *written, (int)(n - *written));
+        if (w > 0) {
+            *written += (size_t)w;
+            continue;
+        }
+        int err = SSL_get_error(tc->ssl, w);
+        if (err == SSL_ERROR_WANT_READ)  { tc->tls_want_r = 1; return M_C_NOTYET; }
+        if (err == SSL_ERROR_WANT_WRITE) { tc->tls_want_w = 1; return M_C_NOTYET; }
+        if (err == SSL_ERROR_ZERO_RETURN) return M_C_CLOSED;
+        return M_C_ERROR;
+    }
+    return M_C_FINISH;
+}
+
+static int mln_tcp_conn_send_tls(mln_tcp_conn_t *tc)
+{
+    int r;
+    mln_chain_t *c;
+    mln_buf_t   *b;
+    int is_done = 0;
+
+    /* Clear stale event-wait flags from a previous M_C_NOTYET so the
+     * caller does not keep registering POLLIN/POLLOUT we no longer
+     * need.  Each branch below sets them only on its own return path.
+     */
+    tc->tls_want_r = tc->tls_want_w = 0;
+
+    if (!tc->tls_done) {
+        r = mln_tcp_conn_tls_handshake(tc);
+        if (r != M_C_FINISH) return r;
+    }
+
+    /* First push any ciphertext that was queued by an earlier partial
+     * write back out to the socket.
+     */
+    r = mln_tcp_conn_tls_flush_wbio(tc);
+    if (r == M_C_ERROR) return r;
+    if (r == M_C_NOTYET) return r;
+
+    while ((c = tc->snd_head) != NULL) {
+        b = c->buf;
+        if (b == NULL) {
+            c = mln_tcp_conn_pop_inline(tc, M_C_SEND);
+            mln_tcp_conn_append(tc, c, M_C_SENT);
+            continue;
+        }
+
+        size_t left = mln_buf_left_size(b);
+        if (left == 0) {
+            if (b->last_in_chain) is_done = 1;
+            c = mln_tcp_conn_pop_inline(tc, M_C_SEND);
+            mln_tcp_conn_append(tc, c, M_C_SENT);
+            if (is_done) break;
+            continue;
+        }
+
+        size_t written = 0;
+        unsigned char stackbuf[M_TLS_CHUNK];
+        const unsigned char *src;
+
+        if (b->in_memory) {
+            size_t n = left > M_TLS_CHUNK ? M_TLS_CHUNK : left;
+            src = (const unsigned char *)b->left_pos;
+            r = mln_tcp_conn_tls_write_one_chunk(tc, src, n, &written);
+            if (written > 0) b->left_pos += written;
+        } else if (b->in_file) {
+            ssize_t rn;
+            size_t n = left > M_TLS_CHUNK ? M_TLS_CHUNK : left;
+            if (lseek(mln_file_fd(b->file), b->file_left_pos, SEEK_SET) < 0)
+                return M_C_ERROR;
+            /* Match the EINTR retry behaviour of the plain in_file path. */
+            for (;;) {
+                rn = read(mln_file_fd(b->file), stackbuf, n);
+                if (rn > 0) break;
+                if (rn < 0 && errno == EINTR) continue;
+                return M_C_ERROR;
+            }
+            r = mln_tcp_conn_tls_write_one_chunk(tc, stackbuf, (size_t)rn, &written);
+            if (written > 0) b->file_left_pos += written;
+        } else {
+            /* Unknown buffer flavour; nothing to send. */
+            c = mln_tcp_conn_pop_inline(tc, M_C_SEND);
+            mln_tcp_conn_append(tc, c, M_C_SENT);
+            continue;
+        }
+
+        /* Flush whatever SSL_write produced before deciding the fate
+         * of this chain.  Only after the ciphertext is actually on the
+         * wire do we consider this buf "sent".
+         */
+        {
+            int fr = mln_tcp_conn_tls_flush_wbio(tc);
+            if (fr == M_C_ERROR) return M_C_ERROR;
+            if (fr == M_C_NOTYET) return M_C_NOTYET;
+        }
+        if (r == M_C_ERROR || r == M_C_CLOSED) return r;
+        if (r == M_C_NOTYET) return M_C_NOTYET;
+
+        if (mln_buf_left_size(b) == 0) {
+            if (b->last_in_chain) is_done = 1;
+            c = mln_tcp_conn_pop_inline(tc, M_C_SEND);
+            mln_tcp_conn_append(tc, c, M_C_SENT);
+            if (is_done) break;
+        }
+    }
+
+    return is_done ? M_C_FINISH : M_C_NOTYET;
+}
+
+/* ------------------------------------------------------------------ *
+ * Recv                                                               *
+ * ------------------------------------------------------------------ *
+ * Decrypted plaintext is appended to rcv_* as fresh memory chains;   *
+ * ciphertext only lives on the stack and inside rbio, so the rcv_*   *
+ * queue is always pure plaintext from the caller's point of view.    *
+ * ------------------------------------------------------------------ */
+
+static int mln_tcp_conn_recv_tls(mln_tcp_conn_t *tc)
+{
+    int dr, p, err;
+
+    tc->tls_want_r = tc->tls_want_w = 0;
+
+    if (!tc->tls_done) {
+        int hr = mln_tcp_conn_tls_handshake(tc);
+        if (hr != M_C_FINISH) return hr;
+    }
+
+    /* Pull ciphertext off the wire and feed it to rbio.
+     */
+    dr = mln_tcp_conn_tls_drain_socket(tc);
+    if (dr == M_C_ERROR) return dr;
+    /* M_C_CLOSED is recorded but we still try SSL_read in case the
+     * shutdown record gives us trailing plaintext / a clean close. */
+
+    /* Decrypt everything currently available. */
+    for (;;) {
+        tc->tls_want_r = tc->tls_want_w = 0;
+        mln_u8ptr_t buf = (mln_u8ptr_t)mln_alloc_m(tc->pool, 4096);
+        if (buf == NULL) { errno = ENOMEM; return M_C_ERROR; }
+
+        p = SSL_read(tc->ssl, buf, 4096);
+        if (p > 0) {
+            /* mln_chain_new_with_buf returns a chain node with its
+             * mln_buf_t already attached.  Internally it makes two
+             * pool allocations but cleans the chain node up if the
+             * buf allocation fails -- callers always observe either
+             * a fully-formed pair or NULL, so we cannot leak one
+             * half.  The 4 KiB plaintext buffer `buf` below is owned
+             * separately by the returned mln_buf_t. */
+            mln_chain_t *nc = mln_chain_new_with_buf(tc->pool);
+            if (nc == NULL) { mln_alloc_free(buf); errno = ENOMEM; return M_C_ERROR; }
+            mln_buf_t *nb = nc->buf;
+            nb->left_pos = nb->pos = nb->start = buf;
+            nb->last     = nb->end             = buf + p;
+            nb->in_memory = 1;
+            nb->last_buf  = 1;
+            mln_tcp_conn_append(tc, nc, M_C_RECV);
+            continue;
+        }
+        mln_alloc_free(buf);
+
+        err = SSL_get_error(tc->ssl, p);
+        if (err == SSL_ERROR_WANT_READ) {
+            tc->tls_want_r = 1;
+            if (dr == M_C_CLOSED) return M_C_CLOSED;
+            return M_C_NOTYET;
+        }
+        if (err == SSL_ERROR_WANT_WRITE) {
+            /* Renegotiation: produce ciphertext and write it out. */
+            tc->tls_want_w = 1;
+            int fr = mln_tcp_conn_tls_flush_wbio(tc);
+            if (fr == M_C_ERROR) return M_C_ERROR;
+            return M_C_NOTYET;
+        }
+        if (err == SSL_ERROR_ZERO_RETURN) return M_C_CLOSED;
+        return M_C_ERROR;
+    }
+}
+
+/* ------------------------------------------------------------------ *
+ * Shutdown                                                           *
+ * ------------------------------------------------------------------ */
+
+MLN_FUNC(, int, mln_tcp_conn_tls_shutdown, (mln_tcp_conn_t *tc), (tc), {
+    int r, err;
+
+    if (tc->ssl == NULL) return M_C_FINISH;
+    if (!tc->tls_done) {
+        /* Nothing to gracefully close; let the caller close the fd. */
+        tc->tls_want_r = tc->tls_want_w = 0;
+        return M_C_FINISH;
+    }
+
+    tc->tls_want_r = tc->tls_want_w = 0;
+
+    for (;;) {
+        r = SSL_shutdown(tc->ssl);
+        /* Flush close_notify (and possibly ack of peer's close_notify). */
+        {
+            int fr = mln_tcp_conn_tls_flush_wbio(tc);
+            if (fr == M_C_ERROR) return M_C_ERROR;
+            if (fr == M_C_NOTYET) {
+                tc->tls_shut = 1;
+                return M_C_NOTYET;
+            }
+        }
+        if (r >= 1) { tc->tls_shut = 1; return M_C_FINISH; }
+        if (r == 0) {
+            /* Sent close_notify; wait for the peer's. */
+            if (tc->nonblock) {
+                tc->tls_want_r = 1;
+                return M_C_NOTYET;
+            }
+            /* Blocking: drain a bit and loop. */
+            int dr = mln_tcp_conn_tls_drain_socket(tc);
+            if (dr == M_C_ERROR) return M_C_ERROR;
+            if (dr == M_C_CLOSED) { tc->tls_shut = 1; return M_C_FINISH; }
+            continue;
+        }
+        err = SSL_get_error(tc->ssl, r);
+        if (err == SSL_ERROR_WANT_READ) {
+            int dr = mln_tcp_conn_tls_drain_socket(tc);
+            if (dr == M_C_ERROR) return M_C_ERROR;
+            if (dr == M_C_CLOSED) { tc->tls_shut = 1; return M_C_FINISH; }
+            if (tc->nonblock && BIO_pending(SSL_get_rbio(tc->ssl)) == 0) {
+                tc->tls_want_r = 1;
+                return M_C_NOTYET;
+            }
+            continue;
+        }
+        if (err == SSL_ERROR_WANT_WRITE) {
+            tc->tls_want_w = 1;
+            return M_C_NOTYET;
+        }
+        return M_C_ERROR;
+    }
+})
+
+#endif /* MLN_TLS */
 

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -141,7 +141,7 @@ MLN_FUNC_VOID(, void, mln_tcp_conn_destroy, (mln_tcp_conn_t *tc), (tc), {
     mln_chain_pool_release_all(mln_tcp_conn_remove(tc, M_C_SEND));
     mln_chain_pool_release_all(mln_tcp_conn_remove(tc, M_C_RECV));
     mln_chain_pool_release_all(mln_tcp_conn_remove(tc, M_C_SENT));
-    mln_alloc_destroy(tc->pool);
+    if (tc->pool) mln_alloc_destroy(tc->pool);
 })
 
 MLN_FUNC_VOID(, void, mln_tcp_conn_append_chain, \
@@ -1239,6 +1239,9 @@ MLN_FUNC(, int, mln_tcp_conn_tls_set_sni, \
      * is either a bug or an attacker-controlled value, and silently
      * truncating would send an incorrect SNI value.  Reject up front. */
     if (hostname->len >= sizeof(buf)) { errno = EINVAL; return -1; }
+    /* An embedded NUL would silently shorten the C-string sent as SNI,
+     * making the verified name differ from what the caller intended. */
+    if (memchr(hostname->data, '\0', hostname->len) != NULL) { errno = EINVAL; return -1; }
     memcpy(buf, hostname->data, hostname->len);
     buf[hostname->len] = '\0';
     if (SSL_set_tlsext_host_name(tc->ssl, buf) != 1) return -1;
@@ -1255,6 +1258,9 @@ MLN_FUNC(, int, mln_tcp_conn_tls_set_verify_host, \
      * that would let an attacker pass verification against a different
      * name than the caller intended. */
     if (hostname->len >= sizeof(buf)) { errno = EINVAL; return -1; }
+    /* An embedded NUL would shorten the C-string and make the verified
+     * name differ from what the caller passed in. */
+    if (memchr(hostname->data, '\0', hostname->len) != NULL) { errno = EINVAL; return -1; }
     memcpy(buf, hostname->data, hostname->len);
     buf[hostname->len] = '\0';
     param = SSL_get0_param(tc->ssl);

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -1012,7 +1012,8 @@ MLN_FUNC(, mln_tcp_tls_conf_t *, mln_tcp_tls_conf_new, \
     }
 
     if (role == M_TLS_SERVER) {
-        if (cert_file == NULL || key_file == NULL) {
+        if (cert_file == NULL || cert_file->len == 0 ||
+            key_file  == NULL || key_file->len  == 0) {
             errno = EINVAL;
             return NULL;
         }
@@ -1073,9 +1074,15 @@ MLN_FUNC(, mln_tcp_tls_conf_t *, mln_tcp_tls_conf_new, \
         if (!ok) goto err;
     }
 
-    SSL_CTX_set_verify(c->ctx,
-                       verify ? SSL_VERIFY_PEER : SSL_VERIFY_NONE,
-                       NULL);
+    {
+        int vmode = SSL_VERIFY_NONE;
+        if (verify) {
+            vmode = SSL_VERIFY_PEER;
+            if (role == M_TLS_SERVER)
+                vmode |= SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+        }
+        SSL_CTX_set_verify(c->ctx, vmode, NULL);
+    }
 
     /* Deep-copy so the conf is self-contained: callers don't have to
      * keep their mln_string_t storage alive for the conf's lifetime.

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -963,78 +963,10 @@ static inline int mln_tcp_conn_recv_chain_mem(int sockfd, mln_alloc_t *pool, mln
 
 #define M_TLS_CHUNK 16384
 
-/* One-shot global OpenSSL init, made thread-safe so concurrent first
- * callers cannot race the legacy (<1.1.0) init path.  On 1.1.0+ the
- * library initialises itself on first use, so the work inside the
- * once-block is empty there; the guard is kept for the rare 1.0.x
- * builds and as a contract anchor.  Same dual pattern as mln_rs.c.
- *
- * The published "inited" flag is declared `volatile long` so the
- * Windows loser-loop sees a fresh value on every iteration, and on
- * the same architecture InterlockedExchange gives us a full memory
- * barrier when the winner publishes.  The POSIX path piggy-backs on
- * pthread_once's happens-before guarantees and ignores the flag's
- * type. */
-#if !defined(MSVC)
-static pthread_once_t mln_tcp_tls_init_once = PTHREAD_ONCE_INIT;
-#else
-static volatile long mln_tcp_tls_init_once_flag = 0;
-#endif
-static volatile long mln_tcp_tls_global_inited = 0;
-
-static void mln_tcp_tls_global_init_inner(void)
-{
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-    SSL_library_init();
-    SSL_load_error_strings();
-    OpenSSL_add_all_algorithms();
-#endif
-#if !defined(MSVC)
-    mln_tcp_tls_global_inited = 1;
-#else
-    /* Publish with a full barrier so the loser loop's volatile load
-     * cannot observe init work reordered after the flag write. */
-    InterlockedExchange(&mln_tcp_tls_global_inited, 1);
-#endif
-}
-
-MLN_FUNC(, int, mln_tcp_tls_global_init, (void), (), {
-#if !defined(MSVC)
-    pthread_once(&mln_tcp_tls_init_once, mln_tcp_tls_global_init_inner);
-#else
-    /* InterlockedCompareExchange winners run the init exactly once;
-     * losers spin until the winner publishes mln_tcp_tls_global_inited.
-     */
-    if (InterlockedCompareExchange(&mln_tcp_tls_init_once_flag, 1, 0) == 0) {
-        mln_tcp_tls_global_init_inner();
-    } else {
-        /* Lose-and-wait path.  Sleep(0) yields the rest of the time
-         * slice to any other ready thread (including the winner), so
-         * we do not peg a core spinning while the init runs. */
-        while (!mln_tcp_tls_global_inited) Sleep(0);
-    }
-#endif
-    return mln_tcp_tls_global_inited ? 0 : -1;
-})
-
-MLN_FUNC_VOID(, void, mln_tcp_tls_global_destroy, (void), (), {
-    /* OpenSSL 1.1+ handles teardown automatically via atexit; pthread_once
-     * cannot be reset, so a deliberate teardown here is intentionally a
-     * no-op.  Kept as a public symbol for API stability across OpenSSL
-     * versions.
-     */
-})
 
 static void mln_tcp_tls_apply_versions(SSL_CTX *ctx, mln_u32_t versions)
 {
     if (versions == 0) versions = M_TLS_VDEFAULT;
-    /* SSL_CTX_set_{min,max}_proto_version were introduced in OpenSSL
-     * 1.1.0.  TLS1_2_VERSION alone is not a sufficient feature test --
-     * it is defined as far back as 1.0.2 where these setters do not
-     * exist.  On older OpenSSL the version mask is silently ignored;
-     * the SSL_CTX still negotiates whatever the library defaults to.
-     */
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     int min_v = 0, max_v = 0;
     if (versions & M_TLS_V1_2) min_v = TLS1_2_VERSION;
     if (versions & M_TLS_V1_3) {
@@ -1053,9 +985,6 @@ static void mln_tcp_tls_apply_versions(SSL_CTX *ctx, mln_u32_t versions)
     }
     if (min_v) SSL_CTX_set_min_proto_version(ctx, min_v);
     if (max_v) SSL_CTX_set_max_proto_version(ctx, max_v);
-#else
-    (void)ctx; (void)versions;
-#endif
 }
 
 MLN_FUNC(, mln_tcp_tls_conf_t *, mln_tcp_tls_conf_new, \
@@ -1066,8 +995,6 @@ MLN_FUNC(, mln_tcp_tls_conf_t *, mln_tcp_tls_conf_new, \
 {
     mln_tcp_tls_conf_t *c;
     const SSL_METHOD   *method;
-
-    if (!mln_tcp_tls_global_inited) (void)mln_tcp_tls_global_init();
 
     /* Reject anything outside the documented role enum up front -- otherwise
      * we'd pick the client method for an unknown value but later set the

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -1560,10 +1560,10 @@ static int mln_tcp_conn_send_tls(mln_tcp_conn_t *tc)
             r = mln_tcp_conn_tls_write_one_chunk(tc, stackbuf, (size_t)rn, &written);
             if (written > 0) b->file_left_pos += written;
         } else {
-            /* Unknown buffer flavour; nothing to send. */
-            c = mln_tcp_conn_pop_inline(tc, M_C_SEND);
-            mln_tcp_conn_append(tc, c, M_C_SENT);
-            continue;
+            /* Unknown buffer flavour — treat as a caller error so
+             * the chain is never silently discarded. */
+            errno = EINVAL;
+            return M_C_ERROR;
         }
 
         /* Flush whatever SSL_write produced before deciding the fate

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -800,7 +800,10 @@ MLN_FUNC(, int, mln_tcp_conn_recv, (mln_tcp_conn_t *tc, mln_u32_t flag), (tc, fl
         /* TLS records always require an intermediate memory buffer for
          * decryption; the file-receive path is intentionally unavailable.
          */
-        ASSERT(flag == M_C_TYPE_MEMORY);
+        if (flag != M_C_TYPE_MEMORY) {
+            errno = EINVAL;
+            return M_C_ERROR;
+        }
         return mln_tcp_conn_recv_tls(tc);
     }
 #endif

--- a/src/mln_connection.c
+++ b/src/mln_connection.c
@@ -1370,19 +1370,26 @@ MLN_FUNC(, int, mln_tcp_conn_tls_handshake, (mln_tcp_conn_t *tc), (tc), {
         }
         err = SSL_get_error(tc->ssl, r);
         if (err == SSL_ERROR_WANT_READ) {
+            /* Capture rbio fill before and after the socket drain so we
+             * can tell whether drain_socket actually made progress.
+             * Checking only `BIO_pending == 0` was fragile -- if rbio
+             * already held a stale partial record from a previous
+             * iteration and the socket has no new bytes, we would
+             * BIO_pending > 0 and loop forever in nonblock mode.
+             * `post <= pre` is the correct "no progress" test. */
+            size_t pre = (size_t)BIO_pending(SSL_get_rbio(tc->ssl));
             int dr = mln_tcp_conn_tls_drain_socket(tc);
             if (dr == M_C_ERROR || dr == M_C_CLOSED) return dr;
+            size_t post = (size_t)BIO_pending(SSL_get_rbio(tc->ssl));
             if (tc->nonblock) {
-                /* Did the drain bring anything new? */
-                if (BIO_pending(SSL_get_rbio(tc->ssl)) == 0) {
+                if (post <= pre) {
                     tc->tls_want_r = 1;
                     return M_C_NOTYET;
                 }
                 continue;
             }
             /* Blocking socket: recv() already blocked once; try the
-             * handshake again now that we have bytes.
-             */
+             * handshake again now that we have bytes. */
             continue;
         }
         if (err == SSL_ERROR_WANT_WRITE) {
@@ -1583,10 +1590,17 @@ static int mln_tcp_conn_recv_tls(mln_tcp_conn_t *tc)
             return M_C_NOTYET;
         }
         if (err == SSL_ERROR_WANT_WRITE) {
-            /* Renegotiation: produce ciphertext and write it out. */
-            tc->tls_want_w = 1;
+            /* Renegotiation: SSL_read wants to push ciphertext.  Flush
+             * it.  If the flush stalled (returns NOTYET) flush_wbio
+             * already set tls_want_w; if it fully drained we're now
+             * waiting for the peer's response, so re-arm for read. */
             int fr = mln_tcp_conn_tls_flush_wbio(tc);
             if (fr == M_C_ERROR) return M_C_ERROR;
+            if (fr == M_C_NOTYET) {
+                /* tls_want_w already set by flush_wbio */
+            } else {
+                tc->tls_want_r = 1;
+            }
             return M_C_NOTYET;
         }
         if (err == SSL_ERROR_ZERO_RETURN) return M_C_CLOSED;
@@ -1636,10 +1650,16 @@ MLN_FUNC(, int, mln_tcp_conn_tls_shutdown, (mln_tcp_conn_t *tc), (tc), {
         }
         err = SSL_get_error(tc->ssl, r);
         if (err == SSL_ERROR_WANT_READ) {
+            /* See the handshake path: use pre/post BIO_pending to decide
+             * whether drain_socket actually made progress, instead of
+             * trusting "rbio is empty" which leaves the spin window
+             * open when a stale partial record sits in rbio. */
+            size_t pre = (size_t)BIO_pending(SSL_get_rbio(tc->ssl));
             int dr = mln_tcp_conn_tls_drain_socket(tc);
             if (dr == M_C_ERROR) return M_C_ERROR;
             if (dr == M_C_CLOSED) { tc->tls_shut = 1; return M_C_FINISH; }
-            if (tc->nonblock && BIO_pending(SSL_get_rbio(tc->ssl)) == 0) {
+            size_t post = (size_t)BIO_pending(SSL_get_rbio(tc->ssl));
+            if (tc->nonblock && post <= pre) {
                 tc->tls_want_r = 1;
                 return M_C_NOTYET;
             }

--- a/t/connection.c
+++ b/t/connection.c
@@ -922,6 +922,9 @@ static int tls_test_attach(mln_tcp_conn_t *tc, int fd, SSL_CTX *ctx, int is_serv
     BIO_set_mem_eof_return(rbio, -1);
     BIO_set_mem_eof_return(wbio, -1);
     SSL_set_bio(tc->ssl, rbio, wbio);
+    /* Ownership transferred to SSL; null our locals so the err path of
+     * any future failure point added below cannot double-free them. */
+    rbio = wbio = NULL;
     if (is_server) SSL_set_accept_state(tc->ssl);
     else           SSL_set_connect_state(tc->ssl);
     return 0;
@@ -933,30 +936,26 @@ err:
     return -1;
 }
 
-/* Drive both ends of the handshake until both report done, or until
- * both incomplete sides return M_C_NOTYET in the same iteration
- * (meaning neither can make progress without the other first writing
- * data — a deadlock on this socketpair).  Returns 0 on success, -1
- * on error or deadlock.
+/* Drive both ends of the handshake until both report done.  The 256
+ * iteration cap protects against a regression that would otherwise
+ * stall forever; we do NOT treat "both sides returned NOTYET in the
+ * same iteration" as deadlock -- that is the normal TLS handshake
+ * flow (client emits ClientHello and waits, server emits ServerHello
+ * and waits, next iteration each side drains the other's record and
+ * makes progress).  Real deadlocks just exhaust the iteration cap.
  */
 static int tls_drive_handshake_pair(mln_tcp_conn_t *s, mln_tcp_conn_t *c)
 {
     for (int i = 0; i < 256; i++) {
         if (mln_tcp_conn_tls_done(s) && mln_tcp_conn_tls_done(c)) return 0;
-        int s_notyet = 0, c_notyet = 0;
         if (!mln_tcp_conn_tls_done(c)) {
             int r = mln_tcp_conn_tls_handshake(c);
             if (r == M_C_ERROR || r == M_C_CLOSED) return -1;
-            if (r == M_C_NOTYET) c_notyet = 1;
         }
         if (!mln_tcp_conn_tls_done(s)) {
             int r = mln_tcp_conn_tls_handshake(s);
             if (r == M_C_ERROR || r == M_C_CLOSED) return -1;
-            if (r == M_C_NOTYET) s_notyet = 1;
         }
-        /* Both pending sides returned NOTYET: neither can make progress
-         * without the other going first — detect and abort. */
-        if (s_notyet && c_notyet) return -1;
     }
     return -1;
 }
@@ -1794,6 +1793,140 @@ out:
     return NULL;
 }
 
+/* Regression test for the non-blocking handshake spin window: when the
+ * remote BIO holds a stale partial record and the socket has no new
+ * bytes, mln_tcp_conn_tls_handshake must return M_C_NOTYET quickly,
+ * not loop while BIO_pending reports the unchanged stale fill.  We
+ * synthesise this state by directly BIO_writing a few bytes of fake
+ * record header into the server SSL's read BIO and draining the
+ * socket so drain_socket adds nothing.  Bounded by a 500 ms wall-
+ * clock check that would trip on a spin. */
+static void test_tls_handshake_partial_record_no_spin(void)
+{
+    printf("Testing TLS handshake (partial record, no-spin)...\n");
+    tls_test_fixture_init();
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]); set_nonblock(fds[1]);
+    mln_tcp_conn_t srv, cli;
+    assert(tls_test_attach(&srv, fds[0], g_server_ctx, 1) == 0);
+    assert(tls_test_attach(&cli, fds[1], g_client_ctx, 0) == 0);
+    mln_tcp_conn_set_nonblock(&srv, 1);
+    mln_tcp_conn_set_nonblock(&cli, 1);
+
+    /* Drain socket fds[0] completely first (in case anything has
+     * already been queued -- shouldn't be, but be defensive). */
+    char tmp[8192];
+    while (read(fds[0], tmp, sizeof tmp) > 0) { /* discard */ }
+
+    /* Inject 4 bytes of a would-be TLS record header into srv->rbio.
+     * A full TLS record header is 5 bytes, so this is intentionally
+     * short: SSL_do_handshake can either consume it greedily into
+     * internal state (in which case rbio is empty after the call) or
+     * leave it in rbio waiting for more.  Either way our handshake
+     * driver MUST return NOTYET promptly because no new bytes will
+     * ever arrive on the socket. */
+    char partial[4] = { 0x16, 0x03, 0x03, 0x00 };
+    assert(BIO_write(SSL_get_rbio(srv.ssl), partial, sizeof partial) == sizeof partial);
+
+    struct timespec t0, t1;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    int r = mln_tcp_conn_tls_handshake(&srv);
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    long us = elapsed_us(&t0, &t1);
+
+    assert(r == M_C_NOTYET);
+    /* 500ms is an enormous budget for a single non-blocking handshake
+     * call -- if we exceed it the function is spinning. */
+    if (us >= 500000L) {
+        fprintf(stderr, "handshake spun for %ld us on partial-record rbio\n", us);
+        abort();
+    }
+    /* The function returned NOTYET, so the want_* flags should be set
+     * to direct the caller to wait for readable data. */
+    assert(mln_tcp_conn_tls_want_read(&srv) ||
+           mln_tcp_conn_tls_want_write(&srv));
+
+    mln_tcp_conn_destroy(&srv);
+    mln_tcp_conn_destroy(&cli);
+    close(fds[0]); close(fds[1]);
+    printf("  PASS: tls handshake bounded on partial rbio (%ld us)\n", us);
+}
+
+/* Negative-path coverage for mln_tcp_tls_conf_new / mln_tcp_conn_tls_init
+ * / set_sni / set_verify_host.  Validates the input checks added by
+ * earlier review rounds. */
+static void test_tls_conf_validation(void)
+{
+    printf("Testing TLS API input validation...\n");
+    tls_test_fixture_init();
+
+    /* (1) Invalid role */
+    errno = 0;
+    mln_tcp_tls_conf_t *bad = mln_tcp_tls_conf_new(
+        99, NULL, NULL, NULL, NULL, 0, 0);
+    assert(bad == NULL);
+    assert(errno == EINVAL);
+
+    /* (2) Server without cert/key */
+    errno = 0;
+    bad = mln_tcp_tls_conf_new(
+        M_TLS_SERVER, NULL, NULL, NULL, NULL, 0, 0);
+    assert(bad == NULL);
+    assert(errno == EINVAL);
+
+    /* (3) Unknown bits in version mask */
+    errno = 0;
+    bad = mln_tcp_tls_conf_new(
+        M_TLS_CLIENT, NULL, NULL, NULL, NULL, 0x100, 0);
+    assert(bad == NULL);
+    assert(errno == EINVAL);
+
+    /* (4) tls_init with NULL conf */
+    mln_tcp_conn_t dummy;
+    errno = 0;
+    assert(mln_tcp_conn_tls_init(&dummy, -1, NULL) < 0);
+    assert(errno == EINVAL);
+
+    /* (5) set_sni / set_verify_host on a real but oversize hostname */
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    mln_tcp_conn_t cli;
+    assert(tls_test_attach(&cli, fds[0], g_client_ctx, 0) == 0);
+
+    char big[300];
+    memset(big, 'a', sizeof big);
+    mln_string_t huge;
+    mln_string_nset(&huge, big, sizeof big);
+    errno = 0;
+    assert(mln_tcp_conn_tls_set_sni(&cli, &huge) == -1);
+    assert(errno == EINVAL);
+    errno = 0;
+    assert(mln_tcp_conn_tls_set_verify_host(&cli, &huge) == -1);
+    assert(errno == EINVAL);
+
+    /* (6) Embedded NUL */
+    char with_nul[] = { 'a', 'b', '\0', 'c', 'd' };
+    mln_string_t nul_host;
+    mln_string_nset(&nul_host, with_nul, sizeof with_nul);
+    errno = 0;
+    assert(mln_tcp_conn_tls_set_sni(&cli, &nul_host) == -1);
+    assert(errno == EINVAL);
+    errno = 0;
+    assert(mln_tcp_conn_tls_set_verify_host(&cli, &nul_host) == -1);
+    assert(errno == EINVAL);
+
+    /* (7) Reasonable inputs succeed */
+    mln_string_t ok_host = mln_string("example.test");
+    assert(mln_tcp_conn_tls_set_sni(&cli, &ok_host) == 0);
+    assert(mln_tcp_conn_tls_set_verify_host(&cli, &ok_host) == 0);
+
+    mln_tcp_conn_destroy(&cli);
+    close(fds[0]); close(fds[1]);
+    printf("  PASS: tls API input validation\n");
+}
+
 static void test_https_e2e_nonblocking(void)
 {
     printf("Testing real HTTPS client/server (10 rounds, non-blocking)...\n");
@@ -1870,6 +2003,8 @@ int main(void)
     printf("\n--- TLS tests ---\n");
     test_tls_handshake_blocking();
     test_tls_handshake_nonblock();
+    test_tls_handshake_partial_record_no_spin();
+    test_tls_conf_validation();
     test_tls_send_recv_short();
     test_tls_send_recv_large();
     test_tls_send_in_file();

--- a/t/connection.c
+++ b/t/connection.c
@@ -1564,10 +1564,29 @@ static int https_recv_message(int fd, mln_tcp_conn_t *c, mln_http_t *http)
         mln_chain_t *in = mln_tcp_conn_remove(c, M_C_RECV);
         if (in != NULL) {
             int pr = mln_http_parse(http, &in);
-            if (in != NULL) mln_chain_pool_release_all(in);
-            if (pr == M_HTTP_RET_DONE)  return 0;
-            if (pr == M_HTTP_RET_ERROR) return -1;
-            /* M_HTTP_RET_OK: need more bytes */
+            if (pr == M_HTTP_RET_DONE) {
+                mln_chain_pool_release_all(in);
+                return 0;
+            }
+            if (pr == M_HTTP_RET_ERROR) {
+                mln_chain_pool_release_all(in);
+                return -1;
+            }
+            /* M_HTTP_RET_OK: need more bytes.
+             * Free only fully-consumed chain nodes (left_pos has reached
+             * last); put any partially or wholly unconsumed chains back
+             * on the recv queue so the next read appends new data after
+             * them without losing the already-received bytes.
+             */
+            mln_chain_t *rem = in;
+            while (rem != NULL && mln_buf_left_size(rem->buf) == 0) {
+                mln_chain_t *tmp = rem;
+                rem = rem->next;
+                tmp->next = NULL;
+                mln_chain_pool_release(tmp);
+            }
+            if (rem != NULL)
+                mln_tcp_conn_append_chain(c, rem, NULL, M_C_RECV);
         }
         if (r == M_C_CLOSED) return -1;
         if (r == M_C_NOTYET) {

--- a/t/connection.c
+++ b/t/connection.c
@@ -933,23 +933,30 @@ err:
     return -1;
 }
 
-/* Drive both ends of the handshake until both report done or both
- * report NOTYET (which means we'd deadlock if we kept polling on this
- * socketpair).  Each iteration calls handshake on whichever side wants
- * progress.  Returns 0 on success.
+/* Drive both ends of the handshake until both report done, or until
+ * both incomplete sides return M_C_NOTYET in the same iteration
+ * (meaning neither can make progress without the other first writing
+ * data — a deadlock on this socketpair).  Returns 0 on success, -1
+ * on error or deadlock.
  */
 static int tls_drive_handshake_pair(mln_tcp_conn_t *s, mln_tcp_conn_t *c)
 {
     for (int i = 0; i < 256; i++) {
         if (mln_tcp_conn_tls_done(s) && mln_tcp_conn_tls_done(c)) return 0;
+        int s_notyet = 0, c_notyet = 0;
         if (!mln_tcp_conn_tls_done(c)) {
             int r = mln_tcp_conn_tls_handshake(c);
             if (r == M_C_ERROR || r == M_C_CLOSED) return -1;
+            if (r == M_C_NOTYET) c_notyet = 1;
         }
         if (!mln_tcp_conn_tls_done(s)) {
             int r = mln_tcp_conn_tls_handshake(s);
             if (r == M_C_ERROR || r == M_C_CLOSED) return -1;
+            if (r == M_C_NOTYET) s_notyet = 1;
         }
+        /* Both pending sides returned NOTYET: neither can make progress
+         * without the other going first — detect and abort. */
+        if (s_notyet && c_notyet) return -1;
     }
     return -1;
 }

--- a/t/connection.c
+++ b/t/connection.c
@@ -859,8 +859,6 @@ static void tls_test_fixture_init(void)
 {
     if (g_server_ctx != NULL) return;
 
-    mln_tcp_tls_global_init();
-
     /* Generate an RSA 2048 key (version-portable via tls_test_genkey). */
     EVP_PKEY *pkey = tls_test_genkey(2048);
     assert(pkey != NULL);
@@ -1784,7 +1782,6 @@ out:
 static void test_https_e2e_nonblocking(void)
 {
     printf("Testing real HTTPS client/server (10 rounds, non-blocking)...\n");
-    mln_tcp_tls_global_init();
 
     char cert_path[64], key_path[64];
     assert(https_make_cert_files(cert_path, key_path) == 0);

--- a/t/connection.c
+++ b/t/connection.c
@@ -974,23 +974,31 @@ static void tls_test_append_mem(mln_tcp_conn_t *tc, const void *data, size_t n)
     mln_tcp_conn_append(tc, ch, M_C_SEND);
 }
 
-/* Drain rcv_* into a flat buffer and return total bytes copied. */
+/* Drain rcv_* into a flat buffer and return total bytes copied.
+ * Advances left_pos to mark consumed bytes; chain nodes that still
+ * have unread data are put back on M_C_RECV so callers may retry. */
 static size_t tls_test_drain_rcv(mln_tcp_conn_t *tc, unsigned char *dst, size_t cap)
 {
     mln_chain_t *c = mln_tcp_conn_remove(tc, M_C_RECV);
     size_t off = 0;
     while (c != NULL) {
+        mln_chain_t *next = c->next;
+        c->next = NULL;
         if (c->buf != NULL) {
             size_t left = mln_buf_left_size(c->buf);
             size_t cp = left > cap - off ? cap - off : left;
             if (cp > 0) {
                 memcpy(dst + off, c->buf->left_pos, cp);
+                c->buf->left_pos += cp;
                 off += cp;
             }
         }
-        mln_chain_t *next = c->next;
-        c->next = NULL;
-        mln_chain_pool_release(c);
+        if (c->buf == NULL || mln_buf_left_size(c->buf) == 0) {
+            mln_chain_pool_release(c);
+        } else {
+            /* Partially consumed — put the remainder back. */
+            mln_tcp_conn_append_chain(tc, c, NULL, M_C_RECV);
+        }
         c = next;
     }
     return off;

--- a/t/connection.c
+++ b/t/connection.c
@@ -9,6 +9,21 @@
 #include <fcntl.h>
 #include <errno.h>
 #include "mln_connection.h"
+#include "mln_file.h"
+
+#if defined(MLN_TLS)
+#include <pthread.h>
+#include <poll.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "mln_http.h"
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#endif
 
 /* Helper function to calculate elapsed time in microseconds */
 static long elapsed_us(struct timespec *start, struct timespec *end)
@@ -805,6 +820,983 @@ static void test_recv_after_nonblock_send(void)
     printf("  PASS: recv after nonblock send\n");
 }
 
+#if defined(MLN_TLS)
+/* ====================================================================
+ *                          TLS test fixtures
+ * ====================================================================
+ * All TLS tests run entirely in-process over an AF_UNIX socketpair, with
+ * a self-signed RSA certificate generated on the fly so the tests need
+ * no external PEM files and no network access.
+ * ==================================================================== */
+
+static SSL_CTX *g_server_ctx = NULL;
+static SSL_CTX *g_client_ctx = NULL;
+
+/* RSA key generation compat shim.  EVP_RSA_gen() is an OpenSSL 3.0
+ * convenience; on 1.1.x we fall back to the EVP_PKEY_keygen path. */
+static EVP_PKEY *tls_test_genkey(int bits)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    return EVP_RSA_gen(bits);
+#else
+    EVP_PKEY     *pkey = NULL;
+    EVP_PKEY_CTX *kctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+    if (kctx == NULL) return NULL;
+    if (EVP_PKEY_keygen_init(kctx) <= 0) goto out;
+    if (EVP_PKEY_CTX_set_rsa_keygen_bits(kctx, bits) <= 0) goto out;
+    if (EVP_PKEY_keygen(kctx, &pkey) <= 0) pkey = NULL;
+out:
+    EVP_PKEY_CTX_free(kctx);
+    return pkey;
+#endif
+}
+
+/* Generate a self-signed test certificate and bake it into the two
+ * shared SSL_CTXs.  Trust is wired up so the client can verify the
+ * server with X509_V_OK.
+ */
+static void tls_test_fixture_init(void)
+{
+    if (g_server_ctx != NULL) return;
+
+    mln_tcp_tls_global_init();
+
+    /* Generate an RSA 2048 key (version-portable via tls_test_genkey). */
+    EVP_PKEY *pkey = tls_test_genkey(2048);
+    assert(pkey != NULL);
+
+    X509 *x = X509_new();
+    ASN1_INTEGER_set(X509_get_serialNumber(x), 1);
+    X509_gmtime_adj(X509_get_notBefore(x), 0);
+    X509_gmtime_adj(X509_get_notAfter(x), 60L * 60L * 24L * 365L);
+    X509_set_pubkey(x, pkey);
+    X509_NAME *name = X509_get_subject_name(x);
+    X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                               (const unsigned char *)"melon-tls-test", -1, -1, 0);
+    X509_set_issuer_name(x, name);
+    assert(X509_sign(x, pkey, EVP_sha256()) > 0);
+
+    g_server_ctx = SSL_CTX_new(TLS_server_method());
+    assert(g_server_ctx != NULL);
+    SSL_CTX_set_mode(g_server_ctx,
+                     SSL_MODE_ENABLE_PARTIAL_WRITE |
+                     SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+    assert(SSL_CTX_use_certificate(g_server_ctx, x) == 1);
+    assert(SSL_CTX_use_PrivateKey(g_server_ctx, pkey) == 1);
+    assert(SSL_CTX_check_private_key(g_server_ctx) == 1);
+
+    g_client_ctx = SSL_CTX_new(TLS_client_method());
+    assert(g_client_ctx != NULL);
+    SSL_CTX_set_mode(g_client_ctx,
+                     SSL_MODE_ENABLE_PARTIAL_WRITE |
+                     SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+    /* Trust our self-signed cert. */
+    X509_STORE *store = SSL_CTX_get_cert_store(g_client_ctx);
+    assert(X509_STORE_add_cert(store, x) == 1);
+    SSL_CTX_set_verify(g_client_ctx, SSL_VERIFY_PEER, NULL);
+
+    X509_free(x);
+    EVP_PKEY_free(pkey);
+}
+
+static void tls_test_fixture_destroy(void)
+{
+    if (g_server_ctx) { SSL_CTX_free(g_server_ctx); g_server_ctx = NULL; }
+    if (g_client_ctx) { SSL_CTX_free(g_client_ctx); g_client_ctx = NULL; }
+}
+
+/* Attach a connection to a raw SSL_CTX by injecting the SSL handle
+ * directly.  mln_tcp_conn_tls_init() is the public entry point but it
+ * needs an mln_tcp_tls_conf_t; for tests we build the SSL_CTX in memory
+ * to avoid touching the filesystem, so this helper duplicates the
+ * minimal init steps using our own SSL_CTX.
+ */
+static int tls_test_attach(mln_tcp_conn_t *tc, int fd, SSL_CTX *ctx, int is_server)
+{
+    BIO *rbio = NULL, *wbio = NULL;
+    if (mln_tcp_conn_init(tc, fd) < 0) return -1;
+    tc->ssl = SSL_new(ctx);
+    if (tc->ssl == NULL) goto err;
+    rbio = BIO_new(BIO_s_mem());
+    wbio = BIO_new(BIO_s_mem());
+    if (rbio == NULL || wbio == NULL) goto err;
+    BIO_set_mem_eof_return(rbio, -1);
+    BIO_set_mem_eof_return(wbio, -1);
+    SSL_set_bio(tc->ssl, rbio, wbio);
+    if (is_server) SSL_set_accept_state(tc->ssl);
+    else           SSL_set_connect_state(tc->ssl);
+    return 0;
+err:
+    if (rbio) BIO_free(rbio);
+    if (wbio) BIO_free(wbio);
+    if (tc->ssl) { SSL_free(tc->ssl); tc->ssl = NULL; }
+    mln_tcp_conn_destroy(tc);
+    return -1;
+}
+
+/* Drive both ends of the handshake until both report done or both
+ * report NOTYET (which means we'd deadlock if we kept polling on this
+ * socketpair).  Each iteration calls handshake on whichever side wants
+ * progress.  Returns 0 on success.
+ */
+static int tls_drive_handshake_pair(mln_tcp_conn_t *s, mln_tcp_conn_t *c)
+{
+    for (int i = 0; i < 256; i++) {
+        if (mln_tcp_conn_tls_done(s) && mln_tcp_conn_tls_done(c)) return 0;
+        if (!mln_tcp_conn_tls_done(c)) {
+            int r = mln_tcp_conn_tls_handshake(c);
+            if (r == M_C_ERROR || r == M_C_CLOSED) return -1;
+        }
+        if (!mln_tcp_conn_tls_done(s)) {
+            int r = mln_tcp_conn_tls_handshake(s);
+            if (r == M_C_ERROR || r == M_C_CLOSED) return -1;
+        }
+    }
+    return -1;
+}
+
+/* Append a memory buf to a connection's send queue. */
+static void tls_test_append_mem(mln_tcp_conn_t *tc, const void *data, size_t n)
+{
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(tc);
+    mln_chain_t *ch = mln_chain_new(pool);
+    mln_buf_t   *b  = mln_buf_new(pool);
+    mln_u8ptr_t  bf = (mln_u8ptr_t)mln_alloc_m(pool, n);
+    assert(ch != NULL);
+    assert(b  != NULL);
+    assert(bf != NULL);
+    memcpy(bf, data, n);
+    ch->buf = b;
+    b->start = b->left_pos = b->pos = bf;
+    b->last  = b->end = bf + n;
+    b->in_memory = 1;
+    b->last_buf = 1;
+    b->last_in_chain = 1;
+    mln_tcp_conn_append(tc, ch, M_C_SEND);
+}
+
+/* Drain rcv_* into a flat buffer and return total bytes copied. */
+static size_t tls_test_drain_rcv(mln_tcp_conn_t *tc, unsigned char *dst, size_t cap)
+{
+    mln_chain_t *c = mln_tcp_conn_remove(tc, M_C_RECV);
+    size_t off = 0;
+    while (c != NULL) {
+        if (c->buf != NULL) {
+            size_t left = mln_buf_left_size(c->buf);
+            size_t cp = left > cap - off ? cap - off : left;
+            if (cp > 0) {
+                memcpy(dst + off, c->buf->left_pos, cp);
+                off += cp;
+            }
+        }
+        mln_chain_t *next = c->next;
+        c->next = NULL;
+        mln_chain_pool_release(c);
+        c = next;
+    }
+    return off;
+}
+
+/* Threaded helper: drives one side of a blocking-mode handshake. */
+struct tls_blocking_thread_arg {
+    mln_tcp_conn_t *conn;
+    int             ok;
+};
+static void *tls_blocking_handshake_thread(void *vp)
+{
+    struct tls_blocking_thread_arg *a = vp;
+    int r = mln_tcp_conn_tls_handshake(a->conn);
+    a->ok = (r == M_C_FINISH);
+    return NULL;
+}
+
+/* Test 1: blocking handshake driven by two threads (one per side).  This
+ * is what the blocking API contract actually promises: a single call
+ * returns M_C_FINISH once the peer makes equivalent progress.
+ */
+static void test_tls_handshake_blocking(void)
+{
+    printf("Testing TLS handshake (blocking, 2 threads)...\n");
+    tls_test_fixture_init();
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t srv, cli;
+    assert(tls_test_attach(&srv, fds[0], g_server_ctx, 1) == 0);
+    assert(tls_test_attach(&cli, fds[1], g_client_ctx, 0) == 0);
+
+    struct tls_blocking_thread_arg sa = { .conn = &srv, .ok = 0 };
+    struct tls_blocking_thread_arg ca = { .conn = &cli, .ok = 0 };
+    pthread_t st, ct;
+    assert(pthread_create(&st, NULL, tls_blocking_handshake_thread, &sa) == 0);
+    assert(pthread_create(&ct, NULL, tls_blocking_handshake_thread, &ca) == 0);
+    pthread_join(st, NULL);
+    pthread_join(ct, NULL);
+    assert(sa.ok && ca.ok);
+    assert(mln_tcp_conn_tls_done(&srv));
+    assert(mln_tcp_conn_tls_done(&cli));
+
+    mln_tcp_conn_destroy(&srv);
+    mln_tcp_conn_destroy(&cli);
+    close(fds[0]); close(fds[1]);
+    printf("  PASS: tls handshake blocking\n");
+}
+
+/* Test 2: non-blocking handshake. */
+static void test_tls_handshake_nonblock(void)
+{
+    printf("Testing TLS handshake (non-blocking)...\n");
+    tls_test_fixture_init();
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]); set_nonblock(fds[1]);
+
+    mln_tcp_conn_t srv, cli;
+    assert(tls_test_attach(&srv, fds[0], g_server_ctx, 1) == 0);
+    assert(tls_test_attach(&cli, fds[1], g_client_ctx, 0) == 0);
+    assert(mln_tcp_conn_set_nonblock(&srv, 1) == 0);
+    assert(mln_tcp_conn_set_nonblock(&cli, 1) == 0);
+
+    int notyet_seen = 0;
+    for (int i = 0; i < 128; i++) {
+        if (mln_tcp_conn_tls_done(&srv) && mln_tcp_conn_tls_done(&cli)) break;
+        int rs = mln_tcp_conn_tls_handshake(&srv);
+        int rc = mln_tcp_conn_tls_handshake(&cli);
+        if (rs == M_C_NOTYET || rc == M_C_NOTYET) notyet_seen++;
+        if (rs == M_C_ERROR || rc == M_C_ERROR) {
+            fprintf(stderr, "handshake error (i=%d rs=%d rc=%d errno=%d)\n",
+                    i, rs, rc, errno);
+            abort();
+        }
+    }
+    assert(mln_tcp_conn_tls_done(&srv) && mln_tcp_conn_tls_done(&cli));
+    assert(notyet_seen > 0); /* we must have transited through NOTYET */
+
+    mln_tcp_conn_destroy(&srv);
+    mln_tcp_conn_destroy(&cli);
+    close(fds[0]); close(fds[1]);
+    printf("  PASS: tls handshake non-blocking (NOTYET transitions: %d)\n", notyet_seen);
+}
+
+/* Test 3: short send/recv round-trip after handshake.  Uses non-blocking
+ * sockets so a single thread can drive both sides; the underlying
+ * mln_tcp_conn_send / mln_tcp_conn_recv code paths are identical.
+ */
+static void test_tls_send_recv_short(void)
+{
+    printf("Testing TLS send/recv (short)...\n");
+    tls_test_fixture_init();
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]); set_nonblock(fds[1]);
+    mln_tcp_conn_t srv, cli;
+    assert(tls_test_attach(&srv, fds[0], g_server_ctx, 1) == 0);
+    assert(tls_test_attach(&cli, fds[1], g_client_ctx, 0) == 0);
+    mln_tcp_conn_set_nonblock(&srv, 1);
+    mln_tcp_conn_set_nonblock(&cli, 1);
+    assert(tls_drive_handshake_pair(&srv, &cli) == 0);
+
+    const char *msg = "hello melon tls";
+    size_t mlen = strlen(msg);
+    tls_test_append_mem(&cli, msg, mlen);
+    int sr = mln_tcp_conn_send(&cli);
+    assert(sr == M_C_FINISH || sr == M_C_NOTYET);
+    int rr = mln_tcp_conn_recv(&srv, M_C_TYPE_MEMORY);
+    assert(rr == M_C_NOTYET || rr == M_C_FINISH);
+
+    unsigned char got[64];
+    size_t n = tls_test_drain_rcv(&srv, got, sizeof got);
+    assert(n == mlen);
+    assert(memcmp(got, msg, mlen) == 0);
+
+    mln_tcp_conn_destroy(&srv);
+    mln_tcp_conn_destroy(&cli);
+    close(fds[0]); close(fds[1]);
+    printf("  PASS: tls send/recv short\n");
+}
+
+/* Test 4: large payload round-trip over non-blocking sockets. */
+static void test_tls_send_recv_large(void)
+{
+    printf("Testing TLS send/recv (large, non-blocking)...\n");
+    tls_test_fixture_init();
+
+    const size_t N = 4u * 1024u * 1024u;
+    unsigned char *payload = malloc(N);
+    unsigned char *recvbuf = malloc(N + 16);
+    assert(payload && recvbuf);
+    for (size_t i = 0; i < N; i++) payload[i] = (unsigned char)(i * 1103515245u + 12345u);
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]); set_nonblock(fds[1]);
+    mln_tcp_conn_t srv, cli;
+    assert(tls_test_attach(&srv, fds[0], g_server_ctx, 1) == 0);
+    assert(tls_test_attach(&cli, fds[1], g_client_ctx, 0) == 0);
+    mln_tcp_conn_set_nonblock(&srv, 1);
+    mln_tcp_conn_set_nonblock(&cli, 1);
+
+    /* finish handshake first */
+    for (int i = 0; i < 512; i++) {
+        if (mln_tcp_conn_tls_done(&srv) && mln_tcp_conn_tls_done(&cli)) break;
+        mln_tcp_conn_tls_handshake(&cli);
+        mln_tcp_conn_tls_handshake(&srv);
+    }
+    assert(mln_tcp_conn_tls_done(&srv));
+
+    tls_test_append_mem(&cli, payload, N);
+
+    size_t got = 0;
+    for (int spin = 0; spin < 65536 && got < N; spin++) {
+        int sr = mln_tcp_conn_send(&cli);
+        assert(sr == M_C_FINISH || sr == M_C_NOTYET);
+        int rr = mln_tcp_conn_recv(&srv, M_C_TYPE_MEMORY);
+        assert(rr == M_C_NOTYET || rr == M_C_FINISH);
+        size_t n = tls_test_drain_rcv(&srv, recvbuf + got, N + 16 - got);
+        got += n;
+    }
+    assert(got == N);
+    assert(memcmp(recvbuf, payload, N) == 0);
+
+    mln_tcp_conn_destroy(&srv);
+    mln_tcp_conn_destroy(&cli);
+    close(fds[0]); close(fds[1]);
+    free(payload); free(recvbuf);
+    printf("  PASS: tls send/recv large (%zu bytes)\n", N);
+}
+
+/* Test 5: file-backed buf goes through SSL_write. */
+static void test_tls_send_in_file(void)
+{
+    printf("Testing TLS send with in-file buf...\n");
+    tls_test_fixture_init();
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]); set_nonblock(fds[1]);
+    mln_tcp_conn_t srv, cli;
+    assert(tls_test_attach(&srv, fds[0], g_server_ctx, 1) == 0);
+    assert(tls_test_attach(&cli, fds[1], g_client_ctx, 0) == 0);
+    mln_tcp_conn_set_nonblock(&srv, 1);
+    mln_tcp_conn_set_nonblock(&cli, 1);
+    assert(tls_drive_handshake_pair(&srv, &cli) == 0);
+
+    /* Build a small temp file containing the payload. */
+    char tmpl[] = "/tmp/mln_tls_test_XXXXXX";
+    int fd = mkstemp(tmpl);
+    assert(fd >= 0);
+    const char *payload = "file-backed-tls-payload-1234567890";
+    size_t plen = strlen(payload);
+    assert(write(fd, payload, plen) == (ssize_t)plen);
+    close(fd);
+
+    mln_alloc_t *pool = mln_tcp_conn_pool_get(&cli);
+    mln_fileset_t *fset = mln_fileset_init(8);
+    assert(fset != NULL);
+    mln_file_t *file = mln_file_open(fset, tmpl);
+    assert(file != NULL);
+    mln_chain_t *ch = mln_chain_new(pool);
+    mln_buf_t   *b  = mln_buf_new(pool);
+    ch->buf = b;
+    b->file = file;
+    b->file_pos = b->file_left_pos = 0;
+    b->file_last = plen;
+    b->in_file = 1;
+    b->last_buf = 1;
+    b->last_in_chain = 1;
+    mln_tcp_conn_append(&cli, ch, M_C_SEND);
+
+    int sr = mln_tcp_conn_send(&cli);
+    assert(sr == M_C_FINISH || sr == M_C_NOTYET);
+    int rr = mln_tcp_conn_recv(&srv, M_C_TYPE_MEMORY);
+    assert(rr == M_C_NOTYET || rr == M_C_FINISH);
+
+    unsigned char got[128];
+    size_t n = tls_test_drain_rcv(&srv, got, sizeof got);
+    assert(n == plen);
+    assert(memcmp(got, payload, plen) == 0);
+
+    unlink(tmpl);
+    mln_tcp_conn_destroy(&srv);
+    mln_tcp_conn_destroy(&cli);
+    mln_fileset_destroy(fset);
+    (void)pool;
+    close(fds[0]); close(fds[1]);
+    printf("  PASS: tls send with in-file buf\n");
+}
+
+/* Test 6: shutdown round-trip. */
+static void test_tls_shutdown(void)
+{
+    printf("Testing TLS shutdown...\n");
+    tls_test_fixture_init();
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]); set_nonblock(fds[1]);
+    mln_tcp_conn_t srv, cli;
+    assert(tls_test_attach(&srv, fds[0], g_server_ctx, 1) == 0);
+    assert(tls_test_attach(&cli, fds[1], g_client_ctx, 0) == 0);
+    mln_tcp_conn_set_nonblock(&srv, 1);
+    mln_tcp_conn_set_nonblock(&cli, 1);
+    assert(tls_drive_handshake_pair(&srv, &cli) == 0);
+
+    int r = mln_tcp_conn_tls_shutdown(&cli);
+    assert(r == M_C_FINISH || r == M_C_NOTYET);
+    /* Drain whatever the client left on the wire so the server can see
+     * close_notify and acknowledge. */
+    int rr = mln_tcp_conn_recv(&srv, M_C_TYPE_MEMORY);
+    /* recv may legitimately return CLOSED here. */
+    (void)rr;
+    int r2 = mln_tcp_conn_tls_shutdown(&srv);
+    (void)r2;
+
+    mln_tcp_conn_destroy(&srv);
+    mln_tcp_conn_destroy(&cli);
+    close(fds[0]); close(fds[1]);
+    printf("  PASS: tls shutdown\n");
+}
+
+/* Test 7: plain (non-TLS) path is still byte-identical: a connection
+ * created via mln_tcp_conn_init() must never enter the TLS branch.
+ */
+static void test_tls_plain_unchanged(void)
+{
+    printf("Testing TLS-enabled build keeps plain path unchanged...\n");
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+
+    mln_tcp_conn_t a, b;
+    assert(mln_tcp_conn_init(&a, fds[0]) == 0);
+    assert(mln_tcp_conn_init(&b, fds[1]) == 0);
+    /* The TLS-enabled fields must be zero-initialized. */
+    assert(!mln_tcp_conn_tls_enabled(&a));
+    assert(!mln_tcp_conn_tls_enabled(&b));
+
+    const char *msg = "plain-path-still-works";
+    size_t mlen = strlen(msg);
+    tls_test_append_mem(&a, msg, mlen);
+    int sr = mln_tcp_conn_send(&a);
+    assert(sr == M_C_FINISH);
+    int rr = mln_tcp_conn_recv(&b, M_C_TYPE_MEMORY);
+    assert(rr == M_C_NOTYET || rr == M_C_FINISH);
+    unsigned char got[64];
+    size_t n = tls_test_drain_rcv(&b, got, sizeof got);
+    assert(n == mlen);
+    assert(memcmp(got, msg, mlen) == 0);
+
+    mln_tcp_conn_destroy(&a);
+    mln_tcp_conn_destroy(&b);
+    close(fds[0]); close(fds[1]);
+    printf("  PASS: plain path unchanged when TLS compiled in\n");
+}
+
+/* Test 8: throughput benchmark.  Reports MB/s but does not assert on a
+ * specific number — CI hardware variance is too large to make it
+ * meaningful — only prints a [WARN] if the rate falls below a very low
+ * floor that would indicate a real regression.
+ */
+static void test_tls_perf_throughput(void)
+{
+    printf("Benchmarking TLS throughput...\n");
+    tls_test_fixture_init();
+
+    const size_t TOTAL = 16u * 1024u * 1024u;   /* 16 MiB */
+    const size_t CHUNK = 64u * 1024u;
+    unsigned char *block = malloc(CHUNK);
+    assert(block != NULL);
+    for (size_t i = 0; i < CHUNK; i++) block[i] = (unsigned char)i;
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]); set_nonblock(fds[1]);
+    mln_tcp_conn_t srv, cli;
+    assert(tls_test_attach(&srv, fds[0], g_server_ctx, 1) == 0);
+    assert(tls_test_attach(&cli, fds[1], g_client_ctx, 0) == 0);
+    mln_tcp_conn_set_nonblock(&srv, 1);
+    mln_tcp_conn_set_nonblock(&cli, 1);
+    for (int i = 0; i < 512; i++) {
+        if (mln_tcp_conn_tls_done(&srv) && mln_tcp_conn_tls_done(&cli)) break;
+        mln_tcp_conn_tls_handshake(&cli);
+        mln_tcp_conn_tls_handshake(&srv);
+    }
+    assert(mln_tcp_conn_tls_done(&srv));
+
+    struct timespec t0, t1;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+
+    size_t sent = 0, recvd = 0;
+    unsigned char sink[64 * 1024];
+    while (recvd < TOTAL) {
+        if (sent < TOTAL && mln_tcp_conn_send_empty(&cli)) {
+            size_t left = TOTAL - sent;
+            size_t n = left > CHUNK ? CHUNK : left;
+            tls_test_append_mem(&cli, block, n);
+            sent += n;
+        }
+        int sr = mln_tcp_conn_send(&cli);
+        (void)sr;
+        int rr = mln_tcp_conn_recv(&srv, M_C_TYPE_MEMORY);
+        (void)rr;
+        recvd += tls_test_drain_rcv(&srv, sink, sizeof sink);
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    long us = elapsed_us(&t0, &t1);
+    double mbs = us > 0 ? ((double)TOTAL / (double)us) : 0.0;  /* MB/s == bytes/us */
+    printf("  INFO: tls throughput = %.1f MB/s (%zu bytes in %ld us)\n",
+           mbs, TOTAL, us);
+    if (mbs < 20.0) {
+        printf("  [WARN] throughput below 20 MB/s; possible regression\n");
+    }
+
+    mln_tcp_conn_destroy(&srv);
+    mln_tcp_conn_destroy(&cli);
+    close(fds[0]); close(fds[1]);
+    free(block);
+    printf("  PASS: tls throughput benchmark\n");
+}
+
+/* Plain-path throughput for comparison (only built when TLS is on so
+ * we can print the ratio in one run; the plain test suite already
+ * exercises this code path independently). */
+static void test_plain_perf_throughput(void)
+{
+    printf("Benchmarking plain TCP throughput (for TLS comparison)...\n");
+    const size_t TOTAL = 16u * 1024u * 1024u;
+    const size_t CHUNK = 64u * 1024u;
+    unsigned char *block = malloc(CHUNK);
+    assert(block != NULL);
+    for (size_t i = 0; i < CHUNK; i++) block[i] = (unsigned char)i;
+
+    int fds[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    set_nonblock(fds[0]); set_nonblock(fds[1]);
+    mln_tcp_conn_t srv, cli;
+    assert(mln_tcp_conn_init(&srv, fds[0]) == 0);
+    assert(mln_tcp_conn_init(&cli, fds[1]) == 0);
+
+    struct timespec t0, t1;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+
+    size_t sent = 0, recvd = 0;
+    unsigned char sink[64 * 1024];
+    while (recvd < TOTAL) {
+        if (sent < TOTAL && mln_tcp_conn_send_empty(&cli)) {
+            size_t left = TOTAL - sent;
+            size_t n = left > CHUNK ? CHUNK : left;
+            tls_test_append_mem(&cli, block, n);
+            sent += n;
+        }
+        int sr = mln_tcp_conn_send(&cli);
+        (void)sr;
+        int rr = mln_tcp_conn_recv(&srv, M_C_TYPE_MEMORY);
+        (void)rr;
+        recvd += tls_test_drain_rcv(&srv, sink, sizeof sink);
+    }
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    long us = elapsed_us(&t0, &t1);
+    double mbs = us > 0 ? ((double)TOTAL / (double)us) : 0.0;
+    printf("  INFO: plain throughput = %.1f MB/s (%zu bytes in %ld us)\n",
+           mbs, TOTAL, us);
+
+    mln_tcp_conn_destroy(&srv);
+    mln_tcp_conn_destroy(&cli);
+    close(fds[0]); close(fds[1]);
+    free(block);
+    printf("  PASS: plain throughput benchmark\n");
+}
+
+/* ====================================================================
+ *                HTTPS end-to-end test (10 request rounds)
+ * ====================================================================
+ * Real loopback TCP between two threads, both sides non-blocking, both
+ * driven via mln_tcp_conn_tls_init + mln_http_init -- i.e. the real
+ * public APIs.  Exercises:
+ *   - server: cert + private key loaded from PEM via mln_tcp_tls_conf_new
+ *   - client: SNI, CA verification, hostname (X509v3 SAN) verification
+ *   - 10 HTTP request / response round-trips on one TLS connection
+ *   - graceful close_notify shutdown on both sides
+ * ==================================================================== */
+
+#define HTTPS_TEST_ROUNDS 10
+#define HTTPS_TEST_CN     "localhost"
+
+/* Write a self-signed RSA-2048 cert (CN=localhost, SAN=DNS:localhost,
+ * IP:127.0.0.1) and matching private key to two temp PEM files.
+ * Returns 0 on success; *cert_path and *key_path are filled in. */
+static int https_make_cert_files(char *cert_path, char *key_path)
+{
+    EVP_PKEY       *pkey = NULL;
+    X509           *x    = NULL;
+    X509_EXTENSION *ext  = NULL;
+    int             cfd  = -1, kfd = -1;
+    FILE           *cf   = NULL, *kf = NULL;
+    int             rc   = -1;
+
+    cert_path[0] = '\0';
+    key_path[0]  = '\0';
+
+    pkey = tls_test_genkey(2048);
+    if (pkey == NULL) goto out;
+
+    x = X509_new();
+    if (x == NULL) goto out;
+    if (ASN1_INTEGER_set(X509_get_serialNumber(x), 1) != 1)                 goto out;
+    if (X509_gmtime_adj(X509_get_notBefore(x), 0) == NULL)                  goto out;
+    if (X509_gmtime_adj(X509_get_notAfter(x), 60L*60L*24L*365L) == NULL)    goto out;
+    if (X509_set_pubkey(x, pkey) != 1)                                      goto out;
+
+    X509_NAME *name = X509_get_subject_name(x);
+    if (X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                                   (const unsigned char *)HTTPS_TEST_CN,
+                                   -1, -1, 0) != 1)                         goto out;
+    if (X509_set_issuer_name(x, name) != 1)                                 goto out;
+
+    ext = X509V3_EXT_conf_nid(NULL, NULL, NID_subject_alt_name,
+                              "DNS:" HTTPS_TEST_CN ",IP:127.0.0.1");
+    if (ext == NULL)                                                        goto out;
+    if (X509_add_ext(x, ext, -1) != 1)                                      goto out;
+
+    if (X509_sign(x, pkey, EVP_sha256()) <= 0)                              goto out;
+
+    strcpy(cert_path, "/tmp/mln_https_cert_XXXXXX");
+    cfd = mkstemp(cert_path);
+    if (cfd < 0) { cert_path[0] = '\0'; goto out; }
+    strcpy(key_path,  "/tmp/mln_https_key_XXXXXX");
+    kfd = mkstemp(key_path);
+    if (kfd < 0) { key_path[0] = '\0'; goto out; }
+
+    cf = fdopen(cfd, "w");
+    if (cf == NULL) goto out;
+    cfd = -1;        /* ownership transferred to FILE* */
+    kf = fdopen(kfd, "w");
+    if (kf == NULL) goto out;
+    kfd = -1;
+
+    if (PEM_write_X509(cf, x) != 1)                                         goto out;
+    if (PEM_write_PrivateKey(kf, pkey, NULL, NULL, 0, NULL, NULL) != 1)     goto out;
+    if (fclose(cf) != 0) { cf = NULL; goto out; }  cf = NULL;
+    if (fclose(kf) != 0) { kf = NULL; goto out; }  kf = NULL;
+
+    rc = 0;
+
+out:
+    if (cf)        fclose(cf);
+    if (kf)        fclose(kf);
+    if (cfd >= 0)  close(cfd);
+    if (kfd >= 0)  close(kfd);
+    if (ext)       X509_EXTENSION_free(ext);
+    if (x)         X509_free(x);
+    if (pkey)      EVP_PKEY_free(pkey);
+    if (rc != 0) {
+        if (cert_path[0]) unlink(cert_path);
+        if (key_path[0])  unlink(key_path);
+    }
+    return rc;
+}
+
+/* A 15-second wall-clock deadline per high-level operation -- long
+ * enough that even Valgrind-slow CI completes, short enough that a
+ * regression cannot hang the test suite indefinitely. */
+#define HTTPS_DEADLINE_US (15LL * 1000LL * 1000LL)
+
+/* Wait up to `timeout_ms` for the desired events on `fd`.  Returns 0
+ * on a successful (or signal-interrupted) wait, -1 on poll() error
+ * or timeout so callers can fail the test deterministically. */
+static int https_wait(int fd, mln_tcp_conn_t *c, int timeout_ms)
+{
+    struct pollfd pfd = { .fd = fd, .events = 0 };
+    if (mln_tcp_conn_tls_want_read(c))  pfd.events |= POLLIN;
+    if (mln_tcp_conn_tls_want_write(c)) pfd.events |= POLLOUT;
+    if (pfd.events == 0) pfd.events = POLLIN | POLLOUT;
+    int n = poll(&pfd, 1, timeout_ms);
+    if (n < 0) return (errno == EINTR) ? 0 : -1;
+    if (n == 0) return -1;   /* poll timeout */
+    return 0;
+}
+
+static int https_deadline_expired(struct timespec *t0)
+{
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return elapsed_us(t0, &now) > HTTPS_DEADLINE_US;
+}
+
+/* Drive the TLS handshake to completion or hard-fail on deadline. */
+static int https_handshake(int fd, mln_tcp_conn_t *c)
+{
+    struct timespec t0; clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (;;) {
+        int r = mln_tcp_conn_tls_handshake(c);
+        if (r == M_C_FINISH) return 0;
+        if (r != M_C_NOTYET) return -1;
+        if (https_wait(fd, c, 5000) < 0) return -1;
+        if (https_deadline_expired(&t0)) return -1;
+    }
+}
+
+/* Receive bytes and feed mln_http_parse until one message is complete. */
+static int https_recv_message(int fd, mln_tcp_conn_t *c, mln_http_t *http)
+{
+    struct timespec t0; clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (;;) {
+        int r = mln_tcp_conn_recv(c, M_C_TYPE_MEMORY);
+        if (r == M_C_ERROR) return -1;
+        mln_chain_t *in = mln_tcp_conn_remove(c, M_C_RECV);
+        if (in != NULL) {
+            int pr = mln_http_parse(http, &in);
+            if (in != NULL) mln_chain_pool_release_all(in);
+            if (pr == M_HTTP_RET_DONE)  return 0;
+            if (pr == M_HTTP_RET_ERROR) return -1;
+            /* M_HTTP_RET_OK: need more bytes */
+        }
+        if (r == M_C_CLOSED) return -1;
+        if (r == M_C_NOTYET) {
+            if (https_wait(fd, c, 5000) < 0) return -1;
+            if (https_deadline_expired(&t0)) return -1;
+        }
+    }
+}
+
+/* Send a generated chain until M_C_FINISH; releases sent buffers. */
+static int https_send_chain(int fd, mln_tcp_conn_t *c,
+                            mln_chain_t *head, mln_chain_t *tail)
+{
+    struct timespec t0; clock_gettime(CLOCK_MONOTONIC, &t0);
+    mln_tcp_conn_append_chain(c, head, tail, M_C_SEND);
+    for (;;) {
+        int r = mln_tcp_conn_send(c);
+        if (r == M_C_FINISH) {
+            mln_chain_pool_release_all(mln_tcp_conn_remove(c, M_C_SENT));
+            return 0;
+        }
+        if (r == M_C_ERROR) return -1;
+        if (https_wait(fd, c, 5000) < 0) return -1;
+        if (https_deadline_expired(&t0)) return -1;
+    }
+}
+
+/* Best-effort graceful close.  Capped at 32 iterations; poll() errors
+ * or timeouts inside https_wait abort early so a vanished peer cannot
+ * hang the test. */
+static void https_drive_shutdown(int fd, mln_tcp_conn_t *c)
+{
+    for (int i = 0; i < 32; i++) {
+        int r = mln_tcp_conn_tls_shutdown(c);
+        if (r != M_C_NOTYET) return;
+        if (https_wait(fd, c, 200) < 0) return;
+    }
+}
+
+struct https_server_arg {
+    int                  listen_fd;
+    mln_tcp_tls_conf_t  *conf;
+    int                  ok;
+};
+
+static void *https_server_thread(void *vp)
+{
+    struct https_server_arg *sa = vp;
+    sa->ok = 0;
+
+    int cfd = accept(sa->listen_fd, NULL, NULL);
+    if (cfd < 0) return NULL;
+    set_nonblock(cfd);
+
+    mln_tcp_conn_t conn;
+    if (mln_tcp_conn_tls_init(&conn, cfd, sa->conf) < 0) { close(cfd); return NULL; }
+    mln_tcp_conn_set_nonblock(&conn, 1);
+
+    if (https_handshake(cfd, &conn) < 0) goto out;
+
+    mln_http_t *http = mln_http_init(&conn, NULL, NULL);
+    if (http == NULL) goto out;
+
+    int rounds_done = 0;
+    while (rounds_done < HTTPS_TEST_ROUNDS) {
+        if (https_recv_message(cfd, &conn, http) < 0) goto out_http;
+        if (mln_http_method_get(http) != M_HTTP_GET) goto out_http;
+
+        /* Echo the X-Iter header value back so the client can verify
+         * round identity end-to-end. */
+        mln_string_t key_iter = mln_string("X-Iter");
+        mln_string_t *iter_v  = mln_http_field_get(http, &key_iter);
+        if (iter_v == NULL) goto out_http;
+        char iter_buf[32];
+        size_t iter_len = iter_v->len < sizeof(iter_buf)-1 ? iter_v->len : sizeof(iter_buf)-1;
+        memcpy(iter_buf, iter_v->data, iter_len);
+        iter_buf[iter_len] = '\0';
+
+        mln_http_reset(http);
+        mln_http_type_set(http, M_HTTP_RESPONSE);
+        mln_http_status_set(http, M_HTTP_OK);
+        mln_http_version_set(http, M_HTTP_VERSION_1_1);
+
+        mln_string_t key_srv = mln_string("Server");
+        mln_string_t val_srv = mln_string("melon-tls-test");
+        mln_string_t key_cl  = mln_string("Content-Length");
+        mln_string_t val_cl  = mln_string("0");
+        mln_string_t val_iter;
+        mln_string_nset(&val_iter, iter_buf, iter_len);
+        if (mln_http_field_set(http, &key_srv,  &val_srv)  < 0) goto out_http;
+        if (mln_http_field_set(http, &key_iter, &val_iter) < 0) goto out_http;
+        if (mln_http_field_set(http, &key_cl,   &val_cl)   < 0) goto out_http;
+
+        mln_chain_t *head = NULL, *tail = NULL;
+        if (mln_http_generate(http, &head, &tail) != M_HTTP_RET_DONE) goto out_http;
+        if (https_send_chain(cfd, &conn, head, tail) < 0) goto out_http;
+        mln_http_reset(http);
+        rounds_done++;
+    }
+    sa->ok = 1;
+
+    https_drive_shutdown(cfd, &conn);
+out_http:
+    mln_http_destroy(http);
+out:
+    mln_tcp_conn_destroy(&conn);
+    close(cfd);
+    return NULL;
+}
+
+struct https_client_arg {
+    in_port_t            port;
+    mln_tcp_tls_conf_t  *conf;
+    int                  ok;
+};
+
+static void *https_client_thread(void *vp)
+{
+    struct https_client_arg *ca = vp;
+    ca->ok = 0;
+
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) return NULL;
+    set_nonblock(fd);
+
+    struct sockaddr_in sa = { 0 };
+    sa.sin_family = AF_INET;
+    sa.sin_port   = htons(ca->port);
+    inet_pton(AF_INET, "127.0.0.1", &sa.sin_addr);
+    int cr = connect(fd, (struct sockaddr *)&sa, sizeof sa);
+    if (cr < 0 && errno != EINPROGRESS) { close(fd); return NULL; }
+    /* Wait for connect to complete. */
+    struct pollfd pfd = { .fd = fd, .events = POLLOUT };
+    poll(&pfd, 1, 5000);
+    int err = 0; socklen_t errlen = sizeof err;
+    getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errlen);
+    if (err != 0) { close(fd); return NULL; }
+
+    mln_tcp_conn_t conn;
+    if (mln_tcp_conn_tls_init(&conn, fd, ca->conf) < 0) { close(fd); return NULL; }
+    mln_tcp_conn_set_nonblock(&conn, 1);
+
+    /* SNI + hostname verification before the handshake starts. */
+    mln_string_t host = mln_string(HTTPS_TEST_CN);
+    if (mln_tcp_conn_tls_set_sni(&conn, &host) < 0)         goto out;
+    if (mln_tcp_conn_tls_set_verify_host(&conn, &host) < 0) goto out;
+
+    if (https_handshake(fd, &conn) < 0) goto out;
+
+    mln_http_t *http = mln_http_init(&conn, NULL, NULL);
+    if (http == NULL) goto out;
+
+    for (int i = 0; i < HTTPS_TEST_ROUNDS; i++) {
+        char iter_buf[16];
+        int iter_len = snprintf(iter_buf, sizeof iter_buf, "%d", i);
+
+        mln_http_reset(http);
+        mln_http_type_set(http, M_HTTP_REQUEST);
+        mln_http_method_set(http, M_HTTP_GET);
+        mln_http_version_set(http, M_HTTP_VERSION_1_1);
+        mln_string_t key_host  = mln_string("Host");
+        mln_string_t key_iter  = mln_string("X-Iter");
+        mln_string_t val_iter;
+        mln_string_nset(&val_iter, iter_buf, (size_t)iter_len);
+        if (mln_http_field_set(http, &key_host, &host)     < 0) goto out_http;
+        if (mln_http_field_set(http, &key_iter, &val_iter) < 0) goto out_http;
+
+        mln_chain_t *head = NULL, *tail = NULL;
+        if (mln_http_generate(http, &head, &tail) != M_HTTP_RET_DONE) goto out_http;
+        if (https_send_chain(fd, &conn, head, tail) < 0) goto out_http;
+
+        mln_http_reset(http);
+        if (https_recv_message(fd, &conn, http) < 0) goto out_http;
+        if (mln_http_type_get(http)   != M_HTTP_RESPONSE) goto out_http;
+        if (mln_http_status_get(http) != M_HTTP_OK)       goto out_http;
+
+        mln_string_t *got = mln_http_field_get(http, &key_iter);
+        if (got == NULL) goto out_http;
+        if (got->len != (mln_size_t)iter_len) goto out_http;
+        if (memcmp(got->data, iter_buf, iter_len) != 0) goto out_http;
+    }
+    ca->ok = 1;
+
+    https_drive_shutdown(fd, &conn);
+out_http:
+    mln_http_destroy(http);
+out:
+    mln_tcp_conn_destroy(&conn);
+    close(fd);
+    return NULL;
+}
+
+static void test_https_e2e_nonblocking(void)
+{
+    printf("Testing real HTTPS client/server (10 rounds, non-blocking)...\n");
+    mln_tcp_tls_global_init();
+
+    char cert_path[64], key_path[64];
+    assert(https_make_cert_files(cert_path, key_path) == 0);
+
+    mln_string_t cert_s, key_s, ca_s;
+    mln_string_nset(&cert_s, cert_path, strlen(cert_path));
+    mln_string_nset(&key_s,  key_path,  strlen(key_path));
+    /* Self-signed: the cert file doubles as the CA bundle for the client. */
+    mln_string_nset(&ca_s,   cert_path, strlen(cert_path));
+
+    mln_tcp_tls_conf_t *srv_conf = mln_tcp_tls_conf_new(
+        M_TLS_SERVER, &cert_s, &key_s, NULL, NULL, M_TLS_VDEFAULT, 0);
+    mln_tcp_tls_conf_t *cli_conf = mln_tcp_tls_conf_new(
+        M_TLS_CLIENT, NULL, NULL, &ca_s, NULL, M_TLS_VDEFAULT, 1);
+    assert(srv_conf && cli_conf);
+
+    int lfd = socket(AF_INET, SOCK_STREAM, 0);
+    assert(lfd >= 0);
+    int one = 1;
+    setsockopt(lfd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof one);
+    struct sockaddr_in la = { 0 };
+    la.sin_family = AF_INET;
+    la.sin_port   = 0; /* ephemeral */
+    inet_pton(AF_INET, "127.0.0.1", &la.sin_addr);
+    assert(bind(lfd, (struct sockaddr *)&la, sizeof la) == 0);
+    assert(listen(lfd, 1) == 0);
+    socklen_t lalen = sizeof la;
+    assert(getsockname(lfd, (struct sockaddr *)&la, &lalen) == 0);
+
+    struct https_server_arg sa = { .listen_fd = lfd, .conf = srv_conf, .ok = 0 };
+    struct https_client_arg ca = { .port = ntohs(la.sin_port), .conf = cli_conf, .ok = 0 };
+    pthread_t st, ct;
+    assert(pthread_create(&st, NULL, https_server_thread, &sa) == 0);
+    assert(pthread_create(&ct, NULL, https_client_thread, &ca) == 0);
+    pthread_join(st, NULL);
+    pthread_join(ct, NULL);
+    assert(sa.ok);
+    assert(ca.ok);
+
+    close(lfd);
+    mln_tcp_tls_conf_free(srv_conf);
+    mln_tcp_tls_conf_free(cli_conf);
+    unlink(cert_path);
+    unlink(key_path);
+    printf("  PASS: HTTPS 10-round round-trip with SNI + CA + hostname verify\n");
+}
+#endif /* MLN_TLS */
+
 int main(void)
 {
     printf("=== Connection Module Comprehensive Tests ===\n\n");
@@ -825,6 +1817,21 @@ int main(void)
     test_recv_error();
     test_send_finish();
     test_recv_after_nonblock_send();
+
+#if defined(MLN_TLS)
+    printf("\n--- TLS tests ---\n");
+    test_tls_handshake_blocking();
+    test_tls_handshake_nonblock();
+    test_tls_send_recv_short();
+    test_tls_send_recv_large();
+    test_tls_send_in_file();
+    test_tls_shutdown();
+    test_tls_plain_unchanged();
+    test_plain_perf_throughput();
+    test_tls_perf_throughput();
+    test_https_e2e_nonblocking();
+    tls_test_fixture_destroy();
+#endif
 
     printf("\n=== All connection tests passed! ===\n");
     return 0;

--- a/t/connection.c
+++ b/t/connection.c
@@ -866,6 +866,7 @@ static void tls_test_fixture_init(void)
     assert(pkey != NULL);
 
     X509 *x = X509_new();
+    assert(x != NULL);
     ASN1_INTEGER_set(X509_get_serialNumber(x), 1);
     X509_gmtime_adj(X509_get_notBefore(x), 0);
     X509_gmtime_adj(X509_get_notAfter(x), 60L * 60L * 24L * 365L);
@@ -1298,13 +1299,20 @@ static void test_tls_plain_unchanged(void)
  * specific number — CI hardware variance is too large to make it
  * meaningful — only prints a [WARN] if the rate falls below a very low
  * floor that would indicate a real regression.
+ *
+ * The total transfer defaults to 1 MiB to keep Valgrind/CI runs fast.
+ * Set the MLN_BENCH_TOTAL_MB environment variable to a larger value
+ * (e.g. 16) for a more representative measurement on fast hardware.
  */
 static void test_tls_perf_throughput(void)
 {
     printf("Benchmarking TLS throughput...\n");
     tls_test_fixture_init();
 
-    const size_t TOTAL = 16u * 1024u * 1024u;   /* 16 MiB */
+    size_t total_mb = 1;
+    const char *env_mb = getenv("MLN_BENCH_TOTAL_MB");
+    if (env_mb) { int v = atoi(env_mb); if (v > 0) total_mb = (size_t)v; }
+    const size_t TOTAL = total_mb * 1024u * 1024u;
     const size_t CHUNK = 64u * 1024u;
     unsigned char *block = malloc(CHUNK);
     assert(block != NULL);
@@ -1362,11 +1370,15 @@ static void test_tls_perf_throughput(void)
 
 /* Plain-path throughput for comparison (only built when TLS is on so
  * we can print the ratio in one run; the plain test suite already
- * exercises this code path independently). */
+ * exercises this code path independently).
+ * Honours the same MLN_BENCH_TOTAL_MB env var as the TLS benchmark. */
 static void test_plain_perf_throughput(void)
 {
     printf("Benchmarking plain TCP throughput (for TLS comparison)...\n");
-    const size_t TOTAL = 16u * 1024u * 1024u;
+    size_t total_mb = 1;
+    const char *env_mb = getenv("MLN_BENCH_TOTAL_MB");
+    if (env_mb) { int v = atoi(env_mb); if (v > 0) total_mb = (size_t)v; }
+    const size_t TOTAL = total_mb * 1024u * 1024u;
     const size_t CHUNK = 64u * 1024u;
     unsigned char *block = malloc(CHUNK);
     assert(block != NULL);
@@ -1686,9 +1698,11 @@ static void *https_client_thread(void *vp)
     if (cr < 0 && errno != EINPROGRESS) { close(fd); return NULL; }
     /* Wait for connect to complete. */
     struct pollfd pfd = { .fd = fd, .events = POLLOUT };
-    poll(&pfd, 1, 5000);
+    int pret;
+    do { pret = poll(&pfd, 1, 5000); } while (pret < 0 && errno == EINTR);
+    if (pret <= 0) { close(fd); return NULL; }  /* timeout or error */
     int err = 0; socklen_t errlen = sizeof err;
-    getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errlen);
+    if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &errlen) < 0) { close(fd); return NULL; }
     if (err != 0) { close(fd); return NULL; }
 
     mln_tcp_conn_t conn;

--- a/t/connection.c
+++ b/t/connection.c
@@ -1295,7 +1295,7 @@ static void test_tls_plain_unchanged(void)
     printf("  PASS: plain path unchanged when TLS compiled in\n");
 }
 
-/* Test 8: throughput benchmark.  Reports MB/s but does not assert on a
+/* Test 8: throughput benchmark.  Reports MiB/s but does not assert on a
  * specific number — CI hardware variance is too large to make it
  * meaningful — only prints a [WARN] if the rate falls below a very low
  * floor that would indicate a real regression.
@@ -1354,11 +1354,12 @@ static void test_tls_perf_throughput(void)
 
     clock_gettime(CLOCK_MONOTONIC, &t1);
     long us = elapsed_us(&t0, &t1);
-    double mbs = us > 0 ? ((double)TOTAL / (double)us) : 0.0;  /* MB/s == bytes/us */
-    printf("  INFO: tls throughput = %.1f MB/s (%zu bytes in %ld us)\n",
+    /* MiB/s: TOTAL bytes over us microseconds, scaled to mebibytes/second */
+    double mbs = us > 0 ? ((double)TOTAL * 1e6 / ((double)us * 1024.0 * 1024.0)) : 0.0;
+    printf("  INFO: tls throughput = %.1f MiB/s (%zu bytes in %ld us)\n",
            mbs, TOTAL, us);
     if (mbs < 20.0) {
-        printf("  [WARN] throughput below 20 MB/s; possible regression\n");
+        printf("  [WARN] throughput below 20 MiB/s; possible regression\n");
     }
 
     mln_tcp_conn_destroy(&srv);
@@ -1371,7 +1372,8 @@ static void test_tls_perf_throughput(void)
 /* Plain-path throughput for comparison (only built when TLS is on so
  * we can print the ratio in one run; the plain test suite already
  * exercises this code path independently).
- * Honours the same MLN_BENCH_TOTAL_MB env var as the TLS benchmark. */
+ * Honours the same MLN_BENCH_TOTAL_MB env var as the TLS benchmark.
+ * Reports MiB/s (TOTAL is computed as MiB × 1024 × 1024 bytes). */
 static void test_plain_perf_throughput(void)
 {
     printf("Benchmarking plain TCP throughput (for TLS comparison)...\n");
@@ -1411,8 +1413,9 @@ static void test_plain_perf_throughput(void)
     }
     clock_gettime(CLOCK_MONOTONIC, &t1);
     long us = elapsed_us(&t0, &t1);
-    double mbs = us > 0 ? ((double)TOTAL / (double)us) : 0.0;
-    printf("  INFO: plain throughput = %.1f MB/s (%zu bytes in %ld us)\n",
+    /* MiB/s: TOTAL bytes over us microseconds, scaled to mebibytes/second */
+    double mbs = us > 0 ? ((double)TOTAL * 1e6 / ((double)us * 1024.0 * 1024.0)) : 0.0;
+    printf("  INFO: plain throughput = %.1f MiB/s (%zu bytes in %ld us)\n",
            mbs, TOTAL, us);
 
     mln_tcp_conn_destroy(&srv);


### PR DESCRIPTION
TLS handling is folded into mln_tcp_conn so that callers, including mln_http, never have to learn a second API.  A connection initialized through the new mln_tcp_conn_tls_init() carries an SSL handle plus two in-memory BIOs; mln_tcp_conn_send / mln_tcp_conn_recv branch on tc->ssl at entry and run the encrypted path when it is non-NULL.

Plaintext only ever flows through snd_* / rcv_* / sent_*.  Ciphertext lives exclusively on the stack and inside the BIOs, so the receive queue can never become a mixed-content list -- a problem any design that pushed decrypted bytes back through mln_tcp_conn_recv() would have hit on the very next event.

sent_* is honoured strictly: a chain moves to sent_* only after the matching ciphertext has been written to the socket.  Partial drains leave the chain at the head of snd_* so callers retry safely.

Server and client roles, blocking and non-blocking sockets, SNI, hostname verification and a graceful close_notify are all supported. in_file bufs are read into a 16 KiB stack buffer before SSL_write.

Build:
  ./configure --enable-tls
The detection probes common Homebrew layouts and honours OPENSSL_INCLUDE and OPENSSL_LIB for override.  Without the flag the build is byte-for- byte unchanged; with the flag enabled but no SSL handle attached the plain hot path adds only one load and one conditional branch.

Tests:
  t/connection.c grows a self-contained TLS suite (self-signed cert
  generated in memory, AF_UNIX socketpair, no network, no PEM files):
  blocking handshake driven by two threads, non-blocking handshake,
  short and 4 MiB send/recv, in_file send, shutdown, plain-path
  regression, and a throughput benchmark printing MB/s for plain vs
  TLS.

Docs:
  docs/book/cn/tcp_io.md and docs/book/en/tcp_io.md gain a TLS
  section covering the new types, functions, status macros, build
  flag, behaviour notes and short server/client snippets.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
[https://github.com/Water-Melon/Melon/blob/master/CONTRIBUTING.md#contributing](https://github.com/Water-Melon/Melon/blob/master/CONTRIBUTING.md#contributing)
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
